### PR TITLE
[fix] 일정 생성시 place 등록 로직 삭제

### DIFF
--- a/backend/src/main/java/org/example/be/domain/schedule/dto/request/ScheduleReqBody.java
+++ b/backend/src/main/java/org/example/be/domain/schedule/dto/request/ScheduleReqBody.java
@@ -1,11 +1,8 @@
 package org.example.be.domain.schedule.dto.request;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
-import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 
 public record ScheduleReqBody(
@@ -16,10 +13,6 @@ public record ScheduleReqBody(
 	LocalDateTime endSchedule,
 
 	@NotBlank(message = "그룹 이름을 입력해주세요.")
-	String groupName,
-
-	@NotEmpty(message = "일정 장소를 하나 이상 등록해주세요.")
-	@Valid
-	List<SchedulePlaceReqBody> schedulePlaces
+	String groupName
 ) {
 }

--- a/backend/src/main/java/org/example/be/domain/schedule/service/ScheduleService.java
+++ b/backend/src/main/java/org/example/be/domain/schedule/service/ScheduleService.java
@@ -80,19 +80,6 @@ public class ScheduleService {
 
 		Schedule schedule = Schedule.create(reqBody.startSchedule(), reqBody.endSchedule(), group);
 
-		for (SchedulePlaceReqBody places : reqBody.schedulePlaces()) {
-			placeValidationService.validateContentIdByPlaceType(places.placeType(), places.contentId());
-
-			SchedulePlace.create(schedule,
-				places.contentId(),
-				places.placeType(),
-				places.visitStart(),
-				places.visitedEnd(),
-				places.dayOrder(),
-				places.orderInDay()
-			);
-		}
-
 		try {
 			Schedule savedSchedule = scheduleRepository.save(schedule);
 			return ScheduleResBody.from(savedSchedule);
@@ -239,20 +226,6 @@ public class ScheduleService {
 
 		schedule.update(reqBody.startSchedule(), reqBody.endSchedule(), group);
 
-		schedule.getSchedulePlaces().clear();
-		scheduleRepository.flush();
-
-		for (SchedulePlaceReqBody places : reqBody.schedulePlaces()) {
-			placeValidationService.validateContentIdByPlaceType(places.placeType(), places.contentId());
-			SchedulePlace.create(schedule,
-				places.contentId(),
-				places.placeType(),
-				places.visitStart(),
-				places.visitedEnd(),
-				places.dayOrder(),
-				places.orderInDay()
-			);
-		}
 		try {
 			Schedule updatedSchedule = scheduleRepository.save(schedule);
 			return ScheduleResBody.from(updatedSchedule);


### PR DESCRIPTION
## 🔖 관련 이슈
> (예시) Closes #103
- Closes #57 

## 🛠️ 작업 내용
> 이번 PR에서 어떤 작업을 했는지 간단히 요약하세요
- 일정 생성 및 수정 로직에서 장소 목록(schedulePlaces) 입력 제거
- 일정 서비스(ScheduleService)의 장소 저장 및 관리 루프 삭제
- 일정(Schedule) 도메인 생성/수정 흐름 단순화 (일정 기본 생성 후 세부 장소 추가 방식으로 전환)

## 🎨 스크린샷 / 화면 예시 (선택)
### 🕒 수정 전

-

### ✨ 수정 후

-

## 👀 리뷰 요청 사항 (선택)
> 특별히 리뷰어가 봐줬으면 하는 부분이 있다면 적어주세요
- 