### PR TITLE
Fix/ddl auto config fix yechan

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -140,6 +140,49 @@ jobs:
 
       - name: verify deployment
         run: |
-          sleep 15
+          set -e
+          
+          # ──────────────────────────────────────────
+          # 1. 컨테이너 기본 상태 확인
+          # ──────────────────────────────────────────
           docker compose -f $HOME/toleave_yechan/docker-compose.prod.yml ps
+
+          # ──────────────────────────────────────────
+          # 2. 이미지 정합성 검증 - GHCR에서 왔는지 확인
+          # ──────────────────────────────────────────
+          IMAGE=$(docker inspect toleave-app --format '{{.Config.Image}}')
+          echo "Deployed image: $IMAGE"
+
+          if [[ "$IMAGE" != ghcr.io/likeliontravel/toleave-backend:* ]]; then
+            echo "::error::배포된 이미지가 GHCR 이미지가 아닙니다: $IMAGE"
+            echo "::error::EC2에 비공식 docker-compose.yml이나 옛 캐시 이미지가 있는지 확인하세요."
+            exit 1
+          fi
+
+          # ──────────────────────────────────────────
+          # 3. 헬스체크 응답 검증 - 최대 60초 폴링
+          # ──────────────────────────────────────────
+          echo "Health check 시작..."
+          for i in {1..30}; do
+            if curl -sf http://localhost:8080/health > /dev/null; then
+              echo "Health check 통과 (시도 $i회)"
+              break
+            fi
+            if [ $i -eq 30 ]; then
+              echo "::error::Health check 실패 (60초 초과)"
+              echo "::error::docker logs toleave-app 으로 부팅 로그 확인 필요"
+              docker logs toleave-app --tail=50
+              exit 1
+            fi
+            sleep 2
+          done
+
+          # ──────────────────────────────────────────
+          # 4. 부팅 로그에서 에러 패턴 감지
+          # ──────────────────────────────────────────
+          if docker logs toleave-app 2>&1 | grep -E "ERROR|FATAL|Exception" | head -5; then
+            echo "::warning::부팅 로그에서 에러 패턴이 감지되었습니다. 위 로그 확인 필요."
+          fi
+
+          echo "배포 검증 완료"
           

--- a/backend/.env.default
+++ b/backend/.env.default
@@ -75,3 +75,8 @@ REDIS_PORT=6379
 # Spring Active Profile
 # ==============================
 SPRING_PROFILES_ACTIVE=local
+
+# ==============================
+# Spring Hibernate DDL Auto
+# ==============================
+DDL_AUTO=NEED_TO_SET

--- a/backend/src/main/java/org/example/be/domain/member/repository/MemberRepository.java
+++ b/backend/src/main/java/org/example/be/domain/member/repository/MemberRepository.java
@@ -13,6 +13,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
 	boolean existsByEmail(String email);
 
+	// CustomOAuth2UserService.loadUser() 에서 이메일 단독 검증으로 변경 후 미사용 중
 	Optional<Member> findByEmailAndOauthProvider(String email, OauthProvider provider);
 
 }

--- a/backend/src/main/java/org/example/be/global/security/config/SecurityConfig.java
+++ b/backend/src/main/java/org/example/be/global/security/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.example.be.global.jwt.util.JsonUt;
 import org.example.be.global.response.CommonResponse;
 import org.example.be.global.security.filter.CustomAuthenticationFilter;
+import org.example.be.global.security.oauth.handler.CustomFailureHandler;
 import org.example.be.global.security.oauth.handler.CustomSuccessHandler;
 import org.example.be.global.security.oauth.service.CustomOAuth2UserService;
 import org.springframework.context.annotation.Bean;
@@ -32,6 +33,7 @@ public class SecurityConfig {
 	private final CustomOAuth2UserService customOAuth2UserService;
 	private final CustomSuccessHandler customSuccessHandler;
 	private final CustomAuthenticationFilter customAuthenticationFilter;
+	private final CustomFailureHandler customFailureHandler;
 
 	// @Bean
 	// public AuthenticationManager authenticationManager(HttpSecurity http) throws Exception {
@@ -85,7 +87,8 @@ public class SecurityConfig {
 			.oauth2Login((oauth2) -> oauth2
 				.userInfoEndpoint((userInfoEndpointConfig) -> userInfoEndpointConfig
 					.userService(customOAuth2UserService))
-				.successHandler(customSuccessHandler))
+				.successHandler(customSuccessHandler)
+				.failureHandler(customFailureHandler))
 
 			.exceptionHandling(
 				exceptionHandling -> exceptionHandling

--- a/backend/src/main/java/org/example/be/global/security/oauth/handler/CustomFailureHandler.java
+++ b/backend/src/main/java/org/example/be/global/security/oauth/handler/CustomFailureHandler.java
@@ -1,0 +1,50 @@
+package org.example.be.global.security.oauth.handler;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class CustomFailureHandler implements AuthenticationFailureHandler {
+
+	// 에러코드를 식별할 수 없을 때 사용하는 기본 코드 (catch-all)
+	private static final String DEFAULT_ERROR_CODE = "oauth_failed";
+
+	@Value("${app.frontend-base-url}")
+	private String frontendBaseUrl;
+
+	@Override
+	public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+		AuthenticationException exception)
+		throws IOException, ServletException {
+
+		String errorCode = DEFAULT_ERROR_CODE;
+		if (exception instanceof OAuth2AuthenticationException oAuth2Ex) {
+			String code = oAuth2Ex.getError().getErrorCode();
+			if (code != null && !code.isBlank()) {
+				errorCode = code;
+			}
+		}
+
+		// 운영 디버깅용: 어떤 코드/메시지로 실패했는지 추적
+		log.warn("OAuth2 로그인 실패: errorCode={}, message={}", errorCode, exception.getMessage());
+
+		// URL 안전성을 위해 인코딩 (에러코드는 ASCII이지만 방어적 인코딩)
+		String encodedErrorCode = URLEncoder.encode(errorCode, StandardCharsets.UTF_8);
+		String redirectUrl = frontendBaseUrl + "/login?oauthError=" + encodedErrorCode;
+		response.sendRedirect(redirectUrl);
+	}
+
+}

--- a/backend/src/main/java/org/example/be/global/security/oauth/service/CustomOAuth2UserService.java
+++ b/backend/src/main/java/org/example/be/global/security/oauth/service/CustomOAuth2UserService.java
@@ -12,6 +12,7 @@ import org.example.be.global.security.oauth.userinfo.OAuth2UserInfo;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 
@@ -34,12 +35,20 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
 		OAuth2UserInfo userInfo = getOAuth2UserInfo(providerTypeCode, oAuth2User.getAttributes());
 
-		Member member = memberRepository.findByEmailAndOauthProvider(userInfo.getEmail(), provider).orElse(null);
+		// 이메일 단독 UNIQUE 정책에 맞춰 email만으로 조회, 이후 member 객체 필드의 provider를 비교
+		Member member = memberRepository.findByEmail(userInfo.getEmail()).orElse(null);
 
 		if (member == null) {
+			// 신규 가입인 경우
 			joinMember(userInfo, provider);
+		} else if (member.getOauthProvider() != provider) {
+			// 동일 이메일이 다른 provider (또는 General)로 이미 가입되어 있는 경우
+			// 개인정보 보호를 위해 어떤 provider로 가입되었는지는 노출하지 않음
+			throw new OAuth2AuthenticationException(new OAuth2Error("email_already_registered"),
+				"다른 로그인 방식으로 가입된 이메일입니다. 해당 방식으로 로그인해주세요.");
 		}
 
+		// email 존재, 같은 provider면 그대로 통과 -> SuccessHandler에서 토큰 발급
 		return oAuth2User;
 	}
 

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -12,7 +12,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: ${DDL_AUTO:validate}
 
   cloud:
     gcp:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,5 +1,11 @@
 server:
   port: 8080
+  error:
+    whitelabel:
+      enabled: false
+    include-message: never
+    include-stacktrace: never
+    include-binding-errors: never
 
 spring:
   application:
@@ -13,13 +19,6 @@ spring:
       enabled: always
   jackson:
     time-zone: Asia/Seoul
-
-  error:
-    whitelabel:
-      enabled: false
-    include-message: never
-    include-stacktrace: never
-    include-binding-errors: never
 
   jpa:
     hibernate:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -23,7 +23,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: ${DDL_AUTO:update}
       naming:
         physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
     show-sql: false


### PR DESCRIPTION
## 🔖 관련 이슈

- Closes #53
- Closes #60 
- Closes #54 
- Closes #56  

## 🛠️ 작업 내용
> 이번 PR에서 어떤 작업을 했는지 간단히 요약하세요

### ddl auto 관련 작업

- Spring Boot 애플리케이션 설정 hibernate: ddl-auto 옵션에 관련한 혼동을 줄이기 위해 application.yml, application-prod.yml에 환경변수 외부화 명시 및 default값 추가
- .env.default에 DDL_AUTO 항목 추가, docker-compose.prod.yml이 애플리케이션 컨테이너 env_file 세팅되어있어 각 환경에서 원하는 옵션을 .env파일에 적어두면 됩니다. 

---

### 배포 이미지 검증 단계 추가 관련
- 기존 docker compose ps만 확인하여 애플리케이션 컨테이너만 올라가면 정상 배포 완료되던 프로세스를 아래 순서로 동작하도록 변경했습니다.

1. 컨테이너 올라갔는지 확인
2. 해당 컨테이너 이미지가 GHCR에서 온 이미지인지 확인
3. 헬스 체크 응답 검증 (기존 도커 ps 헬스체크용으로 파둔 엔드포인트 재활용했습니다. 최대 60초까지 초당 반복하여 확인합니다.) 
4. 위 세 단계 검증 중 로그에 에러 패턴이 감지되면 최종 라인에 정리 보고
5. "배포 검증 완료" 출력 시 배포 완료

코드적인 변경이 많지 않아 file diff 참고해주세요. 

---

### 소셜 로그인 검증 과정 중 email로 가입한 사용자이지만 provider가 다른 경우

- `CustomFailureHandler`를 새로 생성했습니다.

CustomFailureHandler는 아래와 같이  구성되어 있습니다.

```java

package org.example.be.global.security.oauth.handler;

import java.io.IOException;
import java.net.URLEncoder;
import java.nio.charset.StandardCharsets;

import org.springframework.beans.factory.annotation.Value;
import org.springframework.security.core.AuthenticationException;
import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
import org.springframework.security.web.authentication.AuthenticationFailureHandler;
import org.springframework.stereotype.Component;

import jakarta.servlet.ServletException;
import jakarta.servlet.http.HttpServletRequest;
import jakarta.servlet.http.HttpServletResponse;
import lombok.extern.slf4j.Slf4j;

@Slf4j
@Component
public class CustomFailureHandler implements AuthenticationFailureHandler {

	// 에러코드를 식별할 수 없을 때 사용하는 기본 코드 (catch-all)
	private static final String DEFAULT_ERROR_CODE = "oauth_failed";

	@Value("${app.frontend-base-url}")
	private String frontendBaseUrl;

	@Override
	public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
		AuthenticationException exception)
		throws IOException, ServletException {

		String errorCode = DEFAULT_ERROR_CODE;
		if (exception instanceof OAuth2AuthenticationException oAuth2Ex) {
			String code = oAuth2Ex.getError().getErrorCode();
			if (code != null && !code.isBlank()) {
				errorCode = code;
			}
		}

		// 운영 디버깅용: 어떤 코드/메시지로 실패했는지 추적
		log.warn("OAuth2 로그인 실패: errorCode={}, message={}", errorCode, exception.getMessage());

		// URL 안전성을 위해 인코딩 (에러코드는 ASCII이지만 방어적 인코딩)
		String encodedErrorCode = URLEncoder.encode(errorCode, StandardCharsets.UTF_8);
		String redirectUrl = frontendBaseUrl + "/login?oauthError=" + encodedErrorCode;
		response.sendRedirect(redirectUrl);
	}

}

```

- CustomOAuth2UserService.loadUser()가 아래와 같은 검증 로직으로 변경되었습니다.

```java
@Override
	public OAuth2User loadUser(OAuth2UserRequest userRequest)
		throws OAuth2AuthenticationException {

		OAuth2User oAuth2User = super.loadUser(userRequest);

		String providerTypeCode = userRequest.getClientRegistration().getRegistrationId().toUpperCase();

		OauthProvider provider = OauthProvider.valueOf(providerTypeCode);

		OAuth2UserInfo userInfo = getOAuth2UserInfo(providerTypeCode, oAuth2User.getAttributes());

		// 이메일 단독 UNIQUE 정책에 맞춰 email만으로 조회, 이후 member 객체 필드의 provider를 비교
		Member member = memberRepository.findByEmail(userInfo.getEmail()).orElse(null);

		if (member == null) {
			// 신규 가입인 경우
			joinMember(userInfo, provider);
		} else if (member.getOauthProvider() != provider) {
			// 동일 이메일이 다른 provider (또는 General)로 이미 가입되어 있는 경우
			// 개인정보 보호를 위해 어떤 provider로 가입되었는지는 노출하지 않음
			throw new OAuth2AuthenticationException(new OAuth2Error("email_already_registered"),
				"다른 로그인 방식으로 가입된 이메일입니다. 해당 방식으로 로그인해주세요.");
		}

		// email 존재, 같은 provider면 그대로 통과 -> SuccessHandler에서 토큰 발급
		return oAuth2User;
	}
``` 

- 이메일이 같은 유저가 조회되나 해당 유저의 Provider가 로그인하려는 방식의 Provider와 맞지 않을 경우, Error Code를 `email_already_registered`로 지정하고 CustomFailureHandler로 넘깁니다. 
- 위 CustomFailureHandler에서 에러코드를 프론트의 /login페이지로 oauthError파라미터를 붙여 값으로 넣어 리다이렉트시킵니다.
- 프론트는 쿼리 파라미터를 읽어 코드 별 알맞는 메시지를 alert로 띄우는 방식입니다. (담당 팀원 전달 완료)
- 앞으로 oauth 관련 에러 처리 및 코드 결정은 CustomOAuth2UserService.loadUser() 내부에서 전달해주면 됩니다.
- 만약 위와 같이 직접 지정한 경우가 아닌 OAuth2AuthenticationException은 자동으로 DEFAULT_ERROR_CODE인 oauth_failed라는 값으로 쿼리파라미터로 포함해 전달됩니다. 

## 👀 리뷰 요청 사항 (선택)

- application 설정 파일 두 개 (기본프로필, 배포프로필) DDL Auto 옵션 default값을 none 말고 validate로 해보긴 했는데, none으로 그냥 유지할까요? 
전에 제가 none이 낫지 않을까 하는 의견을 냈던 것 같은데 오히려 none 하다가 지금처럼 너무 뒤늦게 발견하는 느낌도 있네요.. 