### PR TITLE
[fix]refresh token 재발급 로직 오류 수정

### DIFF
--- a/backend/src/main/java/org/example/be/domain/board/controller/CommentController.java
+++ b/backend/src/main/java/org/example/be/domain/board/controller/CommentController.java
@@ -45,7 +45,7 @@ public class CommentController {
 	}
 
 	//댓글 작성
-	@PostMapping("{boardId}")
+	@PostMapping("/{boardId}")
 	public ResponseEntity<CommonResponse<CommentResBody>> write(@PathVariable Long boardId,
 		@Valid @RequestBody CommentCreateReqBody reqBody,
 		@AuthenticationPrincipal SecurityUser user) {

--- a/backend/src/main/java/org/example/be/global/security/filter/CustomAuthenticationFilter.java
+++ b/backend/src/main/java/org/example/be/global/security/filter/CustomAuthenticationFilter.java
@@ -65,7 +65,6 @@ public class CustomAuthenticationFilter extends OncePerRequestFilter {
 					// 응답 헤더와 쿠키에 새 토큰 세팅
 					cookieHelper.setCookie("refreshToken", newRefreshToken);
 					cookieHelper.setCookie("accessToken", newAccessToken);
-					response.setHeader("Authorization", newAccessToken); //포스트맨 테스트용
 
 					setAuthenticationFromUser(member);
 

--- a/backend/src/main/java/org/example/be/global/security/filter/CustomAuthenticationFilter.java
+++ b/backend/src/main/java/org/example/be/global/security/filter/CustomAuthenticationFilter.java
@@ -58,13 +58,14 @@ public class CustomAuthenticationFilter extends OncePerRequestFilter {
 			if (getRefreshToken != null && !getRefreshToken.isBlank()) {
 				try {
 					long userId = authTokenService.findRefreshOwner(getRefreshToken);
-					String newRefreshToken = authTokenService.rotateRefresh(getRefreshToken);
 					Member member = memberService.getById(userId);
+					String newRefreshToken = authTokenService.rotateRefresh(getRefreshToken);
 					String newAccessToken = authTokenService.genAccessToken(member);
 
 					// 응답 헤더와 쿠키에 새 토큰 세팅
 					cookieHelper.setCookie("refreshToken", newRefreshToken);
-					response.setHeader("Authorization", newAccessToken);
+					cookieHelper.setCookie("accessToken", newAccessToken);
+					response.setHeader("Authorization", newAccessToken); //포스트맨 테스트용
 
 					setAuthenticationFromUser(member);
 


### PR DESCRIPTION
## 🔖 관련 이슈
> (예시) Closes #103
- Closes #65 

## 🛠️ 작업 내용
> 이번 PR에서 어떤 작업을 했는지 간단히 요약하세요
-   `CustomAuthenticationFilter`: Access Token 만료 시 Refresh Token으로 갱신할 때 `accessToken` 쿠키도 함께 업데이트하도록 수정하여 브라우저의 무한 갱신 루프 및 강제 로그아웃 문제 해결

## 🎨 스크린샷 / 화면 예시 (선택)
### 🕒 수정 전

-

### ✨ 수정 후

-

## 👀 리뷰 요청 사항 (선택)
> 특별히 리뷰어가 봐줬으면 하는 부분이 있다면 적어주세요
- 