### PR TITLE
[fix] 일정 도메인 리팩토링

### DIFF
--- a/backend/src/main/java/org/example/be/domain/schedule/controller/SchedulePlaceController.java
+++ b/backend/src/main/java/org/example/be/domain/schedule/controller/SchedulePlaceController.java
@@ -1,5 +1,7 @@
 package org.example.be.domain.schedule.controller;
 
+import java.util.List;
+
 import org.example.be.domain.schedule.dto.request.SchedulePlaceReqBody;
 import org.example.be.domain.schedule.dto.response.SchedulePlaceResBody;
 import org.example.be.domain.schedule.service.SchedulePlaceService;
@@ -27,11 +29,11 @@ public class SchedulePlaceController {
 
 	// 특정 일정(scheduleId)에 세부 장소 추가
 	@PostMapping("/detail/{scheduleId}")
-	public ResponseEntity<CommonResponse<SchedulePlaceResBody>> createSchedulePlace(
+	public ResponseEntity<CommonResponse<List<SchedulePlaceResBody>>> createSchedulePlace(
 		@PathVariable Long scheduleId,
-		@Valid @RequestBody SchedulePlaceReqBody reqBody,
+		@Valid @RequestBody List<SchedulePlaceReqBody> reqBodies,
 		@AuthenticationPrincipal SecurityUser securityUser) {
-		SchedulePlaceResBody response = schedulePlaceService.createSchedulePlace(scheduleId, reqBody,
+		List<SchedulePlaceResBody> response = schedulePlaceService.createSchedulePlace(scheduleId, reqBodies,
 			securityUser.getId());
 		return ResponseEntity.ok(CommonResponse.success(response, "세부 일정 생성 성공"));
 	}

--- a/backend/src/main/java/org/example/be/domain/schedule/dto/response/SchedulePlaceResBody.java
+++ b/backend/src/main/java/org/example/be/domain/schedule/dto/response/SchedulePlaceResBody.java
@@ -15,9 +15,6 @@ public record SchedulePlaceResBody(
 	Integer dayOrder,
 	Integer orderInDay
 ) {
-	public static SchedulePlaceResBody from(SchedulePlace schedulePlace) {
-		return from(schedulePlace, null);
-	}
 
 	public static SchedulePlaceResBody from(SchedulePlace schedulePlace, String title) {
 		return new SchedulePlaceResBody(

--- a/backend/src/main/java/org/example/be/domain/schedule/dto/response/SchedulePlaceResBody.java
+++ b/backend/src/main/java/org/example/be/domain/schedule/dto/response/SchedulePlaceResBody.java
@@ -8,15 +8,19 @@ import org.example.be.domain.schedule.entity.SchedulePlace;
 public record SchedulePlaceResBody(
 	Long id,
 	String contentId,
+	String title,
 	PlaceType placeType,
 	LocalDateTime visitStart,
-	LocalDateTime visitedEnd, Integer dayOrder,
+	LocalDateTime visitedEnd,
+	Integer dayOrder,
 	Integer orderInDay
 ) {
-	public static SchedulePlaceResBody from(SchedulePlace schedulePlace) {
+	public static SchedulePlaceResBody from(SchedulePlace schedulePlace, String title
+	) {
 		return new SchedulePlaceResBody(
 			schedulePlace.getId(),
 			schedulePlace.getContentId(),
+			title,
 			schedulePlace.getPlaceType(),
 			schedulePlace.getVisitStart(),
 			schedulePlace.getVisitedEnd(),

--- a/backend/src/main/java/org/example/be/domain/schedule/dto/response/SchedulePlaceResBody.java
+++ b/backend/src/main/java/org/example/be/domain/schedule/dto/response/SchedulePlaceResBody.java
@@ -15,8 +15,11 @@ public record SchedulePlaceResBody(
 	Integer dayOrder,
 	Integer orderInDay
 ) {
-	public static SchedulePlaceResBody from(SchedulePlace schedulePlace, String title
-	) {
+	public static SchedulePlaceResBody from(SchedulePlace schedulePlace) {
+		return from(schedulePlace, null);
+	}
+
+	public static SchedulePlaceResBody from(SchedulePlace schedulePlace, String title) {
 		return new SchedulePlaceResBody(
 			schedulePlace.getId(),
 			schedulePlace.getContentId(),

--- a/backend/src/main/java/org/example/be/domain/schedule/dto/response/ScheduleResBody.java
+++ b/backend/src/main/java/org/example/be/domain/schedule/dto/response/ScheduleResBody.java
@@ -13,6 +13,18 @@ public record ScheduleResBody(
 	String groupName,
 	List<SchedulePlaceResBody> schedulePlaces
 ) {
+	public static ScheduleResBody from(Schedule schedule) {
+		return new ScheduleResBody(
+			schedule.getId(),
+			schedule.getStartSchedule(),
+			schedule.getEndSchedule(),
+			schedule.getGroup().getGroupName(),
+			schedule.getSchedulePlaces().stream()
+				.map(place -> SchedulePlaceResBody.from(place, null))
+				.toList()
+		);
+	}
+	
 	public static ScheduleResBody from(Schedule schedule, Map<String, String> placeTitles) {
 		return new ScheduleResBody(
 			schedule.getId(),

--- a/backend/src/main/java/org/example/be/domain/schedule/dto/response/ScheduleResBody.java
+++ b/backend/src/main/java/org/example/be/domain/schedule/dto/response/ScheduleResBody.java
@@ -2,6 +2,7 @@ package org.example.be.domain.schedule.dto.response;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 import org.example.be.domain.schedule.entity.Schedule;
 
@@ -12,14 +13,14 @@ public record ScheduleResBody(
 	String groupName,
 	List<SchedulePlaceResBody> schedulePlaces
 ) {
-	public static ScheduleResBody from(Schedule schedule) {
+	public static ScheduleResBody from(Schedule schedule, Map<String, String> placeTitles) {
 		return new ScheduleResBody(
 			schedule.getId(),
 			schedule.getStartSchedule(),
 			schedule.getEndSchedule(),
 			schedule.getGroup().getGroupName(),
 			schedule.getSchedulePlaces().stream()
-				.map(SchedulePlaceResBody::from)
+				.map(place -> SchedulePlaceResBody.from(place, placeTitles.get(place.getContentId())))
 				.toList()
 		);
 	}

--- a/backend/src/main/java/org/example/be/domain/schedule/dto/response/ScheduleResBody.java
+++ b/backend/src/main/java/org/example/be/domain/schedule/dto/response/ScheduleResBody.java
@@ -13,17 +13,6 @@ public record ScheduleResBody(
 	String groupName,
 	List<SchedulePlaceResBody> schedulePlaces
 ) {
-	public static ScheduleResBody from(Schedule schedule) {
-		return new ScheduleResBody(
-			schedule.getId(),
-			schedule.getStartSchedule(),
-			schedule.getEndSchedule(),
-			schedule.getGroup().getGroupName(),
-			schedule.getSchedulePlaces().stream()
-				.map(place -> SchedulePlaceResBody.from(place, null))
-				.toList()
-		);
-	}
 	
 	public static ScheduleResBody from(Schedule schedule, Map<String, String> placeTitles) {
 		return new ScheduleResBody(

--- a/backend/src/main/java/org/example/be/domain/schedule/service/PlaceValidationService.java
+++ b/backend/src/main/java/org/example/be/domain/schedule/service/PlaceValidationService.java
@@ -19,11 +19,13 @@ import org.example.be.domain.schedule.entity.SchedulePlace;
 import org.example.be.global.exception.BusinessException;
 import org.example.be.global.exception.code.ErrorCode;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class PlaceValidationService {
 
 	private final TouristSpotRepository touristSpotRepository;

--- a/backend/src/main/java/org/example/be/domain/schedule/service/PlaceValidationService.java
+++ b/backend/src/main/java/org/example/be/domain/schedule/service/PlaceValidationService.java
@@ -1,11 +1,23 @@
 package org.example.be.domain.schedule.service;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.example.be.domain.place.accommodation.entity.Accommodation;
+import org.example.be.domain.place.accommodation.repository.AccommodationRepository;
+import org.example.be.domain.place.restaurant.entity.Restaurant;
+import org.example.be.domain.place.restaurant.repository.RestaurantRepository;
+import org.example.be.domain.place.shared.type.PlaceType;
+import org.example.be.domain.place.touristspot.entity.TouristSpot;
+import org.example.be.domain.place.touristspot.repository.TouristSpotRepository;
+import org.example.be.domain.schedule.entity.SchedulePlace;
 import org.example.be.global.exception.BusinessException;
 import org.example.be.global.exception.code.ErrorCode;
-import org.example.be.domain.place.accommodation.repository.AccommodationRepository;
-import org.example.be.domain.place.shared.type.PlaceType;
-import org.example.be.domain.place.restaurant.repository.RestaurantRepository;
-import org.example.be.domain.place.touristspot.repository.TouristSpotRepository;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
@@ -29,5 +41,41 @@ public class PlaceValidationService {
 			throw new BusinessException(ErrorCode.PLACE_NOT_FOUND,
 				"placeType: " + placeType + ", contentId: " + contentId);
 		}
+	}
+
+	public Map<String, String> getPlaceTitles(List<SchedulePlace> schedulePlaces) {
+		if (schedulePlaces == null || schedulePlaces.isEmpty()) {
+			return Collections.emptyMap();
+		}
+
+		Map<PlaceType, Set<String>> contentIdsByType = schedulePlaces.stream()
+			.collect(Collectors.groupingBy(
+				SchedulePlace::getPlaceType, Collectors.mapping(SchedulePlace::getContentId, Collectors.toSet())
+			));
+
+		Map<String, String> placeTitles = new HashMap<>();
+
+		// 관광지
+		Set<String> touristSpotIds = contentIdsByType.getOrDefault(PlaceType.TOURISTSPOT, Collections.emptySet());
+		if (!touristSpotIds.isEmpty()) {
+			placeTitles.putAll(touristSpotRepository.findAllByContentIdIn(new ArrayList<>(touristSpotIds))
+				.stream().collect(Collectors.toMap(TouristSpot::getContentId, TouristSpot::getTitle)));
+		}
+
+		// 음식점
+		Set<String> restaurantIds = contentIdsByType.getOrDefault(PlaceType.RESTAURANT, Collections.emptySet());
+		if (!restaurantIds.isEmpty()) {
+			placeTitles.putAll(restaurantRepository.findAllByContentIdIn(new ArrayList<>(restaurantIds))
+				.stream().collect(Collectors.toMap(Restaurant::getContentId, Restaurant::getTitle)));
+		}
+
+		// 숙박
+		Set<String> accommodationIds = contentIdsByType.getOrDefault(PlaceType.ACCOMMODATION, Collections.emptySet());
+		if (!accommodationIds.isEmpty()) {
+			placeTitles.putAll(accommodationRepository.findAllByContentIdIn(new ArrayList<>(accommodationIds))
+				.stream().collect(Collectors.toMap(Accommodation::getContentId, Accommodation::getTitle)));
+		}
+
+		return placeTitles;
 	}
 }

--- a/backend/src/main/java/org/example/be/domain/schedule/service/SchedulePlaceService.java
+++ b/backend/src/main/java/org/example/be/domain/schedule/service/SchedulePlaceService.java
@@ -1,5 +1,7 @@
 package org.example.be.domain.schedule.service;
 
+import java.util.List;
+
 import org.example.be.domain.group.service.GroupService;
 import org.example.be.domain.schedule.dto.request.SchedulePlaceReqBody;
 import org.example.be.domain.schedule.dto.response.SchedulePlaceResBody;
@@ -23,31 +25,36 @@ public class SchedulePlaceService {
 	private final GroupService groupService;
 
 	@Transactional
-	public SchedulePlaceResBody createSchedulePlace(Long scheduleId, SchedulePlaceReqBody reqBody, Long userId) {
+	public List<SchedulePlaceResBody> createSchedulePlace(Long scheduleId, List<SchedulePlaceReqBody> reqBodies,
+		Long userId) {
 		var schedule = scheduleRepository.findById(scheduleId)
 			.orElseThrow(() -> new BusinessException(ErrorCode.SCHEDULE_NOT_FOUND, "scheduleId: " + scheduleId));
 
 		// 권한 검증: 그룹 창설자만 세부 일정을 추가할 수 있음
 		groupService.validateGroupCreator(schedule.getGroup().getGroupName(), userId);
 
-		placeValidationService.validateContentIdByPlaceType(reqBody.placeType(), reqBody.contentId());
+		List<SchedulePlace> places = reqBodies.stream()
+			.map(reqBody -> {
+				placeValidationService.validateContentIdByPlaceType(reqBody.placeType(), reqBody.contentId());
+				return SchedulePlace.create(
+					schedule,
+					reqBody.contentId(),
+					reqBody.placeType(),
+					reqBody.visitStart(),
+					reqBody.visitedEnd(),
+					reqBody.dayOrder(),
+					reqBody.orderInDay()
+				);
 
-		SchedulePlace schedulePlace = SchedulePlace.create(
-			schedule,
-			reqBody.contentId(),
-			reqBody.placeType(),
-			reqBody.visitStart(),
-			reqBody.visitedEnd(),
-			reqBody.dayOrder(),
-			reqBody.orderInDay()
-		);
+			})
+			.toList();
 
-		try {
-			var saved = schedulePlaceRepository.save(schedulePlace);
-			return SchedulePlaceResBody.from(saved);
-		} catch (Exception e) {
-			throw new BusinessException(ErrorCode.RESOURCE_CREATION_FAILED, "세부 일정 생성 실패 - message: " + e.getMessage());
-		}
+		List<SchedulePlace> savedPlaces = schedulePlaceRepository.saveAll(places);
+
+		return savedPlaces.stream()
+			.map(place -> SchedulePlaceResBody.from(place, null))
+			.toList();
+
 	}
 
 	@Transactional

--- a/backend/src/main/java/org/example/be/domain/schedule/service/SchedulePlaceService.java
+++ b/backend/src/main/java/org/example/be/domain/schedule/service/SchedulePlaceService.java
@@ -52,7 +52,7 @@ public class SchedulePlaceService {
 		List<SchedulePlace> savedPlaces = schedulePlaceRepository.saveAll(places);
 
 		return savedPlaces.stream()
-			.map(place -> SchedulePlaceResBody.from(place, null))
+			.map(SchedulePlaceResBody::from)
 			.toList();
 
 	}

--- a/backend/src/main/java/org/example/be/domain/schedule/service/SchedulePlaceService.java
+++ b/backend/src/main/java/org/example/be/domain/schedule/service/SchedulePlaceService.java
@@ -1,6 +1,7 @@
 package org.example.be.domain.schedule.service;
 
 import java.util.List;
+import java.util.Map;
 
 import org.example.be.domain.group.service.GroupService;
 import org.example.be.domain.schedule.dto.request.SchedulePlaceReqBody;
@@ -51,10 +52,11 @@ public class SchedulePlaceService {
 
 		List<SchedulePlace> savedPlaces = schedulePlaceRepository.saveAll(places);
 
-		return savedPlaces.stream()
-			.map(SchedulePlaceResBody::from)
-			.toList();
+		Map<String, String> placeTitles = placeValidationService.getPlaceTitles(savedPlaces);
 
+		return savedPlaces.stream()
+			.map(place -> SchedulePlaceResBody.from(place, placeTitles.get(place.getContentId())))
+			.toList();
 	}
 
 	@Transactional
@@ -77,7 +79,9 @@ public class SchedulePlaceService {
 		);
 
 		try {
-			return SchedulePlaceResBody.from(schedulePlaceRepository.save(place));
+			SchedulePlace savedPlace = schedulePlaceRepository.save(place);
+			Map<String, String> placeTitles = placeValidationService.getPlaceTitles(List.of(savedPlace));
+			return SchedulePlaceResBody.from(savedPlace, placeTitles.get(savedPlace.getContentId()));
 		} catch (Exception e) {
 			throw new BusinessException(ErrorCode.RESOURCE_UPDATE_FAILED, "세부 일정 수정 실패 - message: " + e.getMessage());
 		}

--- a/backend/src/main/java/org/example/be/domain/schedule/service/ScheduleService.java
+++ b/backend/src/main/java/org/example/be/domain/schedule/service/ScheduleService.java
@@ -81,7 +81,9 @@ public class ScheduleService {
 
 		try {
 			Schedule savedSchedule = scheduleRepository.save(schedule);
-			return ScheduleResBody.from(savedSchedule);
+			// 일정 생성 직후에는 장소가 없을 가능성이 높지만 일관성을 위해 조회
+			Map<String, String> placeTitles = placeValidationService.getPlaceTitles(savedSchedule.getSchedulePlaces());
+			return ScheduleResBody.from(savedSchedule, placeTitles);
 		} catch (Exception e) {
 			throw new BusinessException(ErrorCode.RESOURCE_CREATION_FAILED, "일정 생성 실패 - message: " + e.getMessage());
 		}
@@ -96,26 +98,7 @@ public class ScheduleService {
 		Schedule schedule = scheduleRepository.findByGroup(group)
 			.orElseThrow(() -> new BusinessException(ErrorCode.SCHEDULE_NOT_FOUND, "groupName: " + groupName));
 
-		// PlaceType 별로 contenId 수집하는 로직입니당
-		Map<PlaceType, Set<String>> contentIdsByType = schedule.getSchedulePlaces().stream()
-			.collect(Collectors.groupingBy(
-				SchedulePlace::getPlaceType, Collectors.mapping(SchedulePlace::getContentId, Collectors.toSet())
-			));
-
-		// contenId별로 장소이름 저장 맵입니당
-		Map<String, String> placeTitles = new HashMap<>();
-
-		placeTitles.putAll(touristSpotRepository.findAllByContentIdIn(
-				new ArrayList<>(contentIdsByType.getOrDefault(PlaceType.TOURISTSPOT, Collections.emptySet())))
-			.stream().collect(Collectors.toMap(TouristSpot::getContentId, TouristSpot::getTitle)));
-
-		placeTitles.putAll(restaurantRepository.findAllByContentIdIn(
-				new ArrayList<>(contentIdsByType.getOrDefault(PlaceType.RESTAURANT, Collections.emptySet())))
-			.stream().collect(Collectors.toMap(Restaurant::getContentId, Restaurant::getTitle)));
-
-		placeTitles.putAll(accommodationRepository.findAllByContentIdIn(
-				new ArrayList<>(contentIdsByType.getOrDefault(PlaceType.ACCOMMODATION, Collections.emptySet())))
-			.stream().collect(Collectors.toMap(Accommodation::getContentId, Accommodation::getTitle)));
+		Map<String, String> placeTitles = placeValidationService.getPlaceTitles(schedule.getSchedulePlaces());
 
 		return ScheduleResBody.from(schedule, placeTitles);
 	}
@@ -248,7 +231,10 @@ public class ScheduleService {
 
 		try {
 			Schedule updatedSchedule = scheduleRepository.save(schedule);
-			return ScheduleResBody.from(updatedSchedule);
+			
+			Map<String, String> placeTitles = placeValidationService.getPlaceTitles(
+				updatedSchedule.getSchedulePlaces());
+			return ScheduleResBody.from(updatedSchedule, placeTitles);
 		} catch (Exception e) {
 			throw new BusinessException(ErrorCode.RESOURCE_UPDATE_FAILED, "일정 수정 실패 - message: " + e.getMessage());
 		}

--- a/backend/src/main/java/org/example/be/domain/schedule/service/ScheduleService.java
+++ b/backend/src/main/java/org/example/be/domain/schedule/service/ScheduleService.java
@@ -27,7 +27,6 @@ import org.example.be.domain.place.theme.PlaceCategory;
 import org.example.be.domain.place.theme.PlaceCategoryRepository;
 import org.example.be.domain.place.touristspot.entity.TouristSpot;
 import org.example.be.domain.place.touristspot.repository.TouristSpotRepository;
-import org.example.be.domain.schedule.dto.request.SchedulePlaceReqBody;
 import org.example.be.domain.schedule.dto.request.ScheduleReqBody;
 import org.example.be.domain.schedule.dto.response.ScheduleResBody;
 import org.example.be.domain.schedule.dto.response.ScheduleSummaryResBody;
@@ -97,7 +96,28 @@ public class ScheduleService {
 		Schedule schedule = scheduleRepository.findByGroup(group)
 			.orElseThrow(() -> new BusinessException(ErrorCode.SCHEDULE_NOT_FOUND, "groupName: " + groupName));
 
-		return ScheduleResBody.from(schedule);
+		// PlaceType 별로 contenId 수집하는 로직입니당
+		Map<PlaceType, Set<String>> contentIdsByType = schedule.getSchedulePlaces().stream()
+			.collect(Collectors.groupingBy(
+				SchedulePlace::getPlaceType, Collectors.mapping(SchedulePlace::getContentId, Collectors.toSet())
+			));
+
+		// contenId별로 장소이름 저장 맵입니당
+		Map<String, String> placeTitles = new HashMap<>();
+
+		placeTitles.putAll(touristSpotRepository.findAllByContentIdIn(
+				new ArrayList<>(contentIdsByType.getOrDefault(PlaceType.TOURISTSPOT, Collections.emptySet())))
+			.stream().collect(Collectors.toMap(TouristSpot::getContentId, TouristSpot::getTitle)));
+
+		placeTitles.putAll(restaurantRepository.findAllByContentIdIn(
+				new ArrayList<>(contentIdsByType.getOrDefault(PlaceType.RESTAURANT, Collections.emptySet())))
+			.stream().collect(Collectors.toMap(Restaurant::getContentId, Restaurant::getTitle)));
+
+		placeTitles.putAll(accommodationRepository.findAllByContentIdIn(
+				new ArrayList<>(contentIdsByType.getOrDefault(PlaceType.ACCOMMODATION, Collections.emptySet())))
+			.stream().collect(Collectors.toMap(Accommodation::getContentId, Accommodation::getTitle)));
+
+		return ScheduleResBody.from(schedule, placeTitles);
 	}
 
 	// 일정 요약 목록 조회

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -31,6 +31,12 @@ spring:
       naming:
         physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
     show-sql: false
+    properties:
+      hibernate:
+        jdbc:
+          batch_size: 50
+        order_inserts: true
+        order_updates: true
 
   batch:
     jdbc:


### PR DESCRIPTION
## 🔖 관련 이슈
> (예시) Closes #103
- Closes #69 

## 🛠️ 작업 내용
> 이번 PR에서 어떤 작업을 했는지 간단히 요약하세요
- 세부 일정 장소를 등록할 때 배열 단위로 등록하게 수정했습니답 대신 수정은 건드리지 않았습니다
- 일정 상세 조회 할때 그냥 title을 예찬형 말대로 req에 담아서 하게 되면 나중에 안맞는 제목이 나올 수도 있을 것 같아서 map으로 동적 매핑해서 불러오게 수정해봤어요 괜찮은지 한 번 봐주세요
- 일정 생성 할때 이제 한번에 처리를 하다보니 일정 장소들이 등록 될 때 마다 save 되는 걸 saveALL로 바꾸고 Hibernate batch_size 설정을 50으로 추가해서 묶음으로 처리하게 했습니답

## 🎨 스크린샷 / 화면 예시 (선택)
### 🕒 수정 전

-

### ✨ 수정 후

**1. 타이틀(Title) 동적 매핑 확인**
> 일정 **조회, 세부일정 생성, 수정** API 호출 시 `title` 데이터가  정상적으로 매핑되어 출력되는 것을 확인했습니답

<img width="625" height="474" alt="image" src="https://github.com/user-attachments/assets/f99e103c-d610-4ee1-896f-bdddd99b6a68" />

<img width="582" height="360" alt="image" src="https://github.com/user-attachments/assets/55c82bc6-587f-47d2-8c99-582533453159" />

<img width="545" height="337" alt="image" src="https://github.com/user-attachments/assets/b97ad873-0d0a-496a-b148-288f3cc79431" />

<br>

**2. 세부 일정 일괄 저장 화면**
> 세부 일정을 배열(List) 형태로 전달하여 한 번에 저장(`saveAll`)하는 테스트 화면입니답

<img width="575" height="455" alt="image" src="https://github.com/user-attachments/assets/e1b5936b-b68f-4d89-8cb0-574567b4a07b" />


## 👀 리뷰 요청 사항 (선택)
> 특별히 리뷰어가 봐줬으면 하는 부분이 있다면 적어주세요
- 배치 사이즈 설정을 추가하게 되면어 env에서 db 연결 설정에 배치 최적화가 정상적으로 작동하려면 DB 연결 설정에rewriteBatchedStatements=true 옵션이 필수입니다

> DB_URL=jdbc:mysql://127.0.0.1:3306/toleave?useSSL=false&useUnicode=true&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true&rewriteBatchedStatements=true
전 이렇게 설정 되어 있습니다

그리고 세부 일정은 잘 등록이 되는거 같더라구요 프론트 문제였나봅니다.