### PR TITLE
Fix/group base inheritance yechan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ MEMORY.md
 HISTORY.md
 GEMINI.md
 .gemini/
+
+## ai-docs ref dir
+docs/

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -48,6 +48,10 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    // 테스트코드에서도 Slf4j 사용을 위한 의존성
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
+
     implementation 'org.apache.commons:commons-text:1.10.0'
 
     // WebClient를 사용하기 위한 의존성 추가

--- a/backend/src/main/java/org/example/be/domain/group/entity/Group.java
+++ b/backend/src/main/java/org/example/be/domain/group/entity/Group.java
@@ -7,6 +7,7 @@ import java.util.Set;
 
 import org.example.be.domain.group.announcement.entity.GroupAnnouncement;
 import org.example.be.domain.member.entity.Member;
+import org.example.be.global.entity.Base;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -20,18 +21,15 @@ import jakarta.persistence.ManyToMany;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-import lombok.AllArgsConstructor;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Entity
 @Getter
-@Setter
-@NoArgsConstructor
-@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "user_groups")
-public class Group {
+public class Group extends Base {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/org/example/be/domain/group/entity/Group.java
+++ b/backend/src/main/java/org/example/be/domain/group/entity/Group.java
@@ -12,9 +12,6 @@ import org.example.be.global.entity.Base;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.JoinTable;
 import jakarta.persistence.ManyToMany;
@@ -31,10 +28,6 @@ import lombok.NoArgsConstructor;
 @Table(name = "user_groups")
 public class Group extends Base {
 
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
-
 	@Column(nullable = false, unique = true)
 	private String groupName;   // 그룹명, 중복 불가
 
@@ -42,8 +35,8 @@ public class Group extends Base {
 	@JoinColumn(name = "created_by", nullable = false)
 	private Member createdBy;  // 그룹 창설자
 
-	// group_members라는 조인테이블 생성. groupId와 userId가 연결되어있는 테이블이 될것임.
-	// 자바 상으로는 UnifiedUser를 멤버로 가지는 Set으로 표현.
+	// user_groups_members라는 조인테이블 생성. groupId와 userId가 연결되어있는 테이블이 될것임.
+	// 자바 상으로는 Member를 멤버로 가지는 Set으로 표현.
 	@ManyToMany
 	@JoinTable(
 		name = "user_groups_members",
@@ -57,14 +50,29 @@ public class Group extends Base {
 	@OneToMany(mappedBy = "group", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<GroupAnnouncement> announcements = new ArrayList<>();
 
-	// UnifiedUser를 멤버에 추가해주는 함수
-	public void addMember(Member user) {
-		this.members.add(user);
+	// 그룹에 멤버를 추가한다. (조인 테이블 user_groups_members에 매핑 행 생성)
+	public void addMember(Member member) {
+		this.members.add(member);
 	}
 
-	// UnifiedUser를 멤버에서 제거해주는 함수
-	public void removeMember(Member user) {
-		this.members.remove(user);
+	// 그룹에서 멤버를 제거한다. (조인 테이블 user_groups_members에서 매핑 행 사라짐)
+	public void removeMember(Member member) {
+		this.members.remove(member);
+	}
+
+	// --- 팩토리 메서드 ---
+	// 그룹 생성용 정적 팩토리 메서드
+	public static Group create(String groupName, Member createdBy, String description) {
+		Group group = new Group();
+		group.groupName = groupName;
+		group.createdBy = createdBy;
+		group.description = description;
+		return group;
+	}
+
+	// 그룹 설명 수정
+	public void updateDescription(String description) {
+		this.description = description;
 	}
 
 }

--- a/backend/src/main/java/org/example/be/domain/group/entity/Group.java
+++ b/backend/src/main/java/org/example/be/domain/group/entity/Group.java
@@ -62,11 +62,15 @@ public class Group extends Base {
 
 	// --- 팩토리 메서드 ---
 	// 그룹 생성용 정적 팩토리 메서드
+	// 이 메서드는 아래 두 가지 불변법칙을 엔티티에 캡슐화
+	// 1. 요청자는 그룹의 창설자다
+	// 2. 그룹 창설자는 그룹의 멤버다
 	public static Group create(String groupName, Member createdBy, String description) {
 		Group group = new Group();
 		group.groupName = groupName;
 		group.createdBy = createdBy;
 		group.description = description;
+		group.addMember(createdBy); // 창설자를 그룹 멤버로 자동 등록
 		return group;
 	}
 

--- a/backend/src/main/java/org/example/be/domain/group/service/GroupService.java
+++ b/backend/src/main/java/org/example/be/domain/group/service/GroupService.java
@@ -61,10 +61,7 @@ public class GroupService {
 
 		Member creator = memberService.getById(memberId);
 
-		Group group = new Group();
-		group.setGroupName(request.groupName());
-		group.setDescription(request.description());
-		group.setCreatedBy(creator);
+		Group group = Group.create(request.groupName(), creator, request.description());
 		group.addMember(creator);
 
 		Group savedGroup = groupRepository.save(group);
@@ -131,7 +128,7 @@ public class GroupService {
 		}
 
 		Group group = getGroupByName(groupName);
-		group.setDescription(description);
+		group.updateDescription(description);
 		groupRepository.save(group);
 
 		return new GroupModifyResBody(groupName, description);

--- a/backend/src/main/java/org/example/be/domain/group/service/GroupService.java
+++ b/backend/src/main/java/org/example/be/domain/group/service/GroupService.java
@@ -62,7 +62,6 @@ public class GroupService {
 		Member creator = memberService.getById(memberId);
 
 		Group group = Group.create(request.groupName(), creator, request.description());
-		group.addMember(creator);
 
 		Group savedGroup = groupRepository.save(group);
 

--- a/backend/src/main/resources/db/migration/V2__add_user_groups_base_columns.sql
+++ b/backend/src/main/resources/db/migration/V2__add_user_groups_base_columns.sql
@@ -1,0 +1,6 @@
+-- Group 엔티티가 Base 엔티티를 상속하면서 생기는 컬럼 업데이트
+-- 기존 튜플은 created_at, updated_at 값이 Null로 채워지고, 이후 Auditing이 INSERT/UPDATE 시 자동 기록한다.
+
+ALTER TABLE `user_groups`
+    ADD COLUMN `created_at` DATETIME,
+    ADD COLUMN `updated_at` DATETIME;

--- a/backend/src/main/resources/db/migration/V3__rename_mislabeled_snake_columns_to_camel.sql
+++ b/backend/src/main/resources/db/migration/V3__rename_mislabeled_snake_columns_to_camel.sql
@@ -1,0 +1,113 @@
+-- =============================================================================
+-- V3: V1__init.sql이 snake_case로 잘못 만든 컬럼들을 엔티티(SSOT, camelCase)에 맞게 정정.
+--
+-- 배경:
+--   - 이 프로젝트의 Hibernate 명명 전략은 무변환(PhysicalNamingStrategyStandardImpl)이라,
+--     @Column(name=...)이 없는 camelCase 필드는 DB 컬럼도 camelCase여야 한다.
+--   - 그러나 V1__init.sql은 다수 컬럼을 snake로 만들어, 빈 DB 신규 배포 시 validate가 깨진다.
+--
+-- 안전성(핵심):
+--   - 운영 DB는 과거 ddl-auto가 만든 camelCase 스키마라 snake 컬럼이 "이미 없다".
+--     (baseline=V1이라 V1은 재실행되지 않지만, V2/V3는 운영 DB에서도 실행된다.)
+--   - 따라서 각 RENAME을 "해당 snake 컬럼이 존재할 때만" 수행하도록 조건부로 만든다.
+--       · 빈 DB : V1이 snake 컬럼 생성 → 조건 참 → 실제 RENAME 수행
+--       · 운영 DB: snake 컬럼 없음        → 조건 거짓 → no-op (안전)
+-- =============================================================================
+
+-- 0. 재실행 안전을 위해 동일 프로시저가 남아있으면 제거
+DROP PROCEDURE IF EXISTS rename_column_if_exists;
+
+-- 1. 조건부 RENAME 헬퍼 프로시저: old 컬럼이 현재 스키마에 존재할 때만 new 로 변경
+CREATE PROCEDURE rename_column_if_exists(
+    IN p_table VARCHAR(64),
+    IN p_old   VARCHAR(64),
+    IN p_new   VARCHAR(64)
+)
+BEGIN
+      IF EXISTS (
+          SELECT 1
+          FROM information_schema.COLUMNS
+          WHERE TABLE_SCHEMA = DATABASE()
+            AND TABLE_NAME   = p_table
+            AND COLUMN_NAME  = p_old
+      ) THEN
+          SET @ddl = CONCAT(
+              'ALTER TABLE `', p_table, '` RENAME COLUMN `', p_old, '` TO `', p_new, '`'
+          );
+          PREPARE stmt FROM @ddl;
+          EXECUTE stmt;
+          DEALLOCATE PREPARE stmt;
+      END IF;
+END;
+
+  -- 2. snake → camel 정정 (총 41개 컬럼)
+
+  -- member
+CALL rename_column_if_exists('member', 'password_changed_at', 'passwordChangedAt');
+CALL rename_column_if_exists('member', 'policy_agreed',       'policyAgreed');
+CALL rename_column_if_exists('member', 'oauth_provider',      'oauthProvider');
+
+-- board
+CALL rename_column_if_exists('board', 'board_hits',           'boardHits');
+CALL rename_column_if_exists('board', 'thumbnail_public_url', 'thumbnailPublicUrl');
+
+-- comment
+CALL rename_column_if_exists('comment', 'comment_content', 'commentContent');
+
+-- user_groups (groupName 의 인라인 UNIQUE 는 RENAME 시 자동 반영)
+CALL rename_column_if_exists('user_groups', 'group_name', 'groupName');
+
+-- group_announcement
+CALL rename_column_if_exists('group_announcement', 'writer_name', 'writerName');
+CALL rename_column_if_exists('group_announcement', 'time_stamp',  'timeStamp');
+
+-- group_invitation
+--   주의: created_at/expires_at 는 Base 감사컬럼이 아니라 GroupInvitation 자체 camel 필드다.
+--         (다른 테이블의 created_at/updated_at 은 진짜 Base 컬럼이므로 건드리지 않는다.)
+CALL rename_column_if_exists('group_invitation', 'invitation_code', 'invitationCode');
+CALL rename_column_if_exists('group_invitation', 'created_at',      'createdAt');
+CALL rename_column_if_exists('group_invitation', 'expires_at',      'expiresAt');
+
+-- schedule
+CALL rename_column_if_exists('schedule', 'start_schedule', 'startSchedule');
+CALL rename_column_if_exists('schedule', 'end_schedule',   'endSchedule');
+
+-- schedule_place
+--   주의: 여기 content_id 는 명시 @Column 이 없어 camel(contentId)로 정정한다.
+--         반면 place 3종(아래)의 content_id 는 @Column(name="content_id")라 그대로 둔다.
+CALL rename_column_if_exists('schedule_place', 'content_id',   'contentId');
+CALL rename_column_if_exists('schedule_place', 'place_type',   'placeType');
+CALL rename_column_if_exists('schedule_place', 'visit_start',  'visitStart');
+CALL rename_column_if_exists('schedule_place', 'visited_end',  'visitedEnd');
+CALL rename_column_if_exists('schedule_place', 'day_order',    'dayOrder');
+CALL rename_column_if_exists('schedule_place', 'order_in_day', 'orderInDay');
+
+-- accommodation (Place 상속 공통 컬럼)
+CALL rename_column_if_exists('accommodation', 'image_url',           'imageUrl');
+CALL rename_column_if_exists('accommodation', 'thumbnail_image_url', 'thumbnailImageUrl');
+CALL rename_column_if_exists('accommodation', 'map_x',               'mapX');
+CALL rename_column_if_exists('accommodation', 'map_y',               'mapY');
+CALL rename_column_if_exists('accommodation', 'm_level',             'mLevel');
+CALL rename_column_if_exists('accommodation', 'created_time',        'createdTime');
+CALL rename_column_if_exists('accommodation', 'modified_time',       'modifiedTime');
+
+-- restaurant (Place 상속 공통 컬럼)
+CALL rename_column_if_exists('restaurant', 'image_url',           'imageUrl');
+CALL rename_column_if_exists('restaurant', 'thumbnail_image_url', 'thumbnailImageUrl');
+CALL rename_column_if_exists('restaurant', 'map_x',               'mapX');
+CALL rename_column_if_exists('restaurant', 'map_y',               'mapY');
+CALL rename_column_if_exists('restaurant', 'm_level',             'mLevel');
+CALL rename_column_if_exists('restaurant', 'created_time',        'createdTime');
+CALL rename_column_if_exists('restaurant', 'modified_time',       'modifiedTime');
+
+-- tourist_spot (Place 상속 공통 컬럼)
+CALL rename_column_if_exists('tourist_spot', 'image_url',           'imageUrl');
+CALL rename_column_if_exists('tourist_spot', 'thumbnail_image_url', 'thumbnailImageUrl');
+CALL rename_column_if_exists('tourist_spot', 'map_x',               'mapX');
+CALL rename_column_if_exists('tourist_spot', 'map_y',               'mapY');
+CALL rename_column_if_exists('tourist_spot', 'm_level',             'mLevel');
+CALL rename_column_if_exists('tourist_spot', 'created_time',        'createdTime');
+CALL rename_column_if_exists('tourist_spot', 'modified_time',       'modifiedTime');
+
+-- 3. 헬퍼 프로시저 정리
+DROP PROCEDURE rename_column_if_exists;

--- a/backend/src/test/java/org/example/be/schedule/service/SchedulePerformanceTest.java
+++ b/backend/src/test/java/org/example/be/schedule/service/SchedulePerformanceTest.java
@@ -50,7 +50,6 @@ public class SchedulePerformanceTest {
 
 		Group group = Group.create("PERF_TEST_GROUP_" + System.currentTimeMillis(), member, null);
 		groupRepository.save(group);
-		group.addMember(member);
 
 		Schedule schedule = Schedule.create(LocalDateTime.now(), LocalDateTime.now().plusDays(3), group);
 		scheduleRepository.save(schedule);

--- a/backend/src/test/java/org/example/be/schedule/service/SchedulePerformanceTest.java
+++ b/backend/src/test/java/org/example/be/schedule/service/SchedulePerformanceTest.java
@@ -48,9 +48,7 @@ public class SchedulePerformanceTest {
 			.orElseThrow(() -> new RuntimeException("회원을 찾을 수 없습니다."));
 		testUserId = member.getId();
 
-		Group group = new Group();
-		group.setGroupName("PERF_TEST_GROUP_" + System.currentTimeMillis());
-		group.setCreatedBy(member);
+		Group group = Group.create("PERF_TEST_GROUP_" + System.currentTimeMillis(), member, null);
 		groupRepository.save(group);
 		group.addMember(member);
 

--- a/backend/src/test/java/org/example/be/schedule/service/SchedulePerformanceTest.java
+++ b/backend/src/test/java/org/example/be/schedule/service/SchedulePerformanceTest.java
@@ -21,6 +21,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 @SpringBootTest
 @Transactional
 public class SchedulePerformanceTest {
@@ -44,7 +47,7 @@ public class SchedulePerformanceTest {
 
 	@BeforeEach
 	void setUp() {
-		Member member = memberRepository.findByEmail("yjc7241@naver.com")
+		Member member = memberRepository.findByEmail("yechani99@naver.com")
 			.orElseThrow(() -> new RuntimeException("회원을 찾을 수 없습니다."));
 		testUserId = member.getId();
 
@@ -65,7 +68,7 @@ public class SchedulePerformanceTest {
 	@Test
 	@DisplayName("N+1 최적화 성능 벤치마크 (데이터 100건 기준)")
 	void comparePerformance() {
-		System.out.println("⏳ 기존 방식(N+1) 측정 시작...");
+		log.info("\n⏳ 기존 방식(N+1) 측정 시작...");
 		long startOld = System.currentTimeMillis();
 
 		List<SchedulePlace> places = schedulePlaceRepository.findAll();
@@ -76,7 +79,7 @@ public class SchedulePerformanceTest {
 		long endOld = System.currentTimeMillis();
 		long oldDuration = endOld - startOld;
 
-		System.out.println("⏳ 개선 방식(Batch) 측정 시작...");
+		log.info("\n⏳ 개선 방식(Batch) 측정 시작...");
 		long startNew = System.currentTimeMillis();
 
 		scheduleService.getScheduleList(testUserId);
@@ -86,14 +89,19 @@ public class SchedulePerformanceTest {
 
 		double improvement = ((double)(oldDuration - newDuration) / oldDuration) * 100;
 
-		System.out.println("\n================================================");
-		System.out.println("📊 [성능 테스트 결과 분석 - 데이터 " + DUMMY_COUNT + "건]");
-		System.out.println("------------------------------------------------");
-		System.out.println("❌ 기존 방식 (N+1 개별 조회): " + oldDuration + " ms");
-		System.out.println("✅ 개선 방식 (Batch 벌크 조회): " + newDuration + " ms");
-		System.out.println("------------------------------------------------");
-		System.out.println("🔥 성능 향상률: " + String.format("%.2f", improvement) + "%");
-		System.out.println("💡 쿼리 감소: " + (DUMMY_COUNT + "회 -> 약 6회 미만"));
-		System.out.println("================================================\n");
+		log.info("""
+				
+				================================================
+				📊 [성능 테스트 결과 분석 - 데이터 {}건]
+				------------------------------------------------
+				❌ 기존 방식 (N+1 개별 조회): {} ms
+				✅ 개선 방식 (Batch 벌크 조회): {} ms
+				------------------------------------------------
+				🔥 성능 향상률: {}%
+				💡 쿼리 감소: {}회 -> 약 6회 미만
+				================================================
+				""",
+			DUMMY_COUNT, oldDuration, newDuration, String.format("%.2f", improvement), DUMMY_COUNT);
+
 	}
 }


### PR DESCRIPTION
## 🔖 관련 이슈

- Closes #55 

## 🛠️ 작업 내용

- Base 엔티티 Group이 상속하도록 변경
- Group 엔티티에서 Setter, AllArgsConstructor 삭제 및 기본 생성자 접근제어 레벨 Protected 설정 (Lazy 로딩 시 값 가져오는 데에 문제 안생기도록)
- 그룹 객체 생성에 대하여 정적 팩토리 메서드 적용
- setter 삭제로 인해 그룹 설명 변경용 메서드 엔티티에 추가
- 엔티티 코드의 UnifiedUser 관련 잔존 주석 수정
- 추가된 created_at, updated_at 컬럼 적용 sql (flyway migration V2) 작성
- 일정 테스트코드의 Group 생성자 -> 새로 생성한 팩토리 메서드로 변경

--- 2026.06.02 추가 ---
- flyway migration V1 이상컬럼명 V3 작성으로 컬럼명 정합성 보장 작업 진행


## 👀 리뷰 요청 사항 (선택)

- flyway 마이그레이션 파일 파일명, 내부 내용 확인 부탁드려요.
- 너무 간단하게만 변경한 것 같아서 팩토리메서드 패턴 활용할만한 다른 로직이 있을지 봐주세요.

---

~~번외~~

~~우선 전에는 몰랐는데 리뷰어 에이전트 돌려서 이제야 알아낸 사실이 있습니다..~~

##  ~~V2 작성 과정에서 claude code가 피드백을 준 게 있습니다.~~
- ~~현재 V1 init 파일 내부 컬럼명들이 실제 db 컬럼명과 상이한 부분이 많습니다.~~
- ~~지금까지 개발해오면서 명시적으로 일반 컬럼명을 camelCase로 지정한 부분, 관계 및 제약에 관련된 컬럼 명을 snake_case로 작성했었는데, V1 은 관례상 전부 snake_case로 작성된 것으로 보여요. 현재 실제 컬럼명과 불일치한 V1 컬럼명이 23개 있습니다. <-이건 마크다운 파일로 레포트 형식으로 정리해서 갖고 있습니다.~~
- ~~사실 이게 당장은 문제가 안됩니다 (flyway 동작 상 V1이 baseline으로 설정되어 있고, 이미 존재하는 테이블에 대해서는 넘어가기 때문)~~
- ~~근데 테이블 자체를 삭제하거나 실운영 전 db 초기화 후 실행하거나 이럴 때 엔티티 필드명과 충돌이 나게 됩니다.~~
- ~~회의 때 컬럼명 정리본과 최종 제안본 드릴게요 관련해서 얘기해보는걸로~~

--- 

## V3 마이그레이션 파일 추가 후 검증

- V1만 실행되어있는 현 운영DB상황과 동일한 상황에서 V2, V3 실행 시 정상 동작 확인 ✅
- 그러나 우려했던 빈 DB상황에서의 컬럼명 충돌을 해결할 수 있는지 검증하기 위해 아래 검증 과정 거침
1. 아예 빈 DB 생성해서 애플리케이션이 해당 스키마를 가리키도록 .env 임시 수정
2. V1 ~ V3까지 존재하는 상태로 (Baseline은 그대로 1) 애플리케이션 실행
3. flyway가 V1부터 순차적으로 execute
4. camelCase, snake_case 검증 쿼리 claude code로 생성해 확인 (의도 컬럼명이 아닌 경우 컬럼 41개 중 ok 미출력 행 발생)
5. 41 row ok 확인 (아래 스크린샷 참고)

### 스크린샷

<img width="1086" height="675" alt="스크린샷 2026-06-03 00 31 47" src="https://github.com/user-attachments/assets/94f495b3-6e7c-46a2-9b3f-1aabe8b7495f" />

<br>

<img width="1157" height="68" alt="스크린샷 2026-06-03 00 40 29" src="https://github.com/user-attachments/assets/e79205fe-61b5-43e0-b77f-dc6c026cd565" />


