### PR TITLE
migration: V4 수동인덱스 누락 정보 추가

### DIFF
--- a/backend/src/main/resources/db/migration/V4__add_placecategory_theme_index.sql
+++ b/backend/src/main/resources/db/migration/V4__add_placecategory_theme_index.sql
@@ -1,0 +1,17 @@
+-- place_category.theme 조회 성능 인덱스 (PlaceCategoryRepository.findFirstByTheme 대상)
+-- 운영 DB(toleave)에는 2026-06-12 수동 CREATE INDEX로 이미 생성됨(마이그레이션 미기록 상태였음).
+-- 신규/로컬 DB에는 없으므로, 환경 간 SSOT를 맞추기 위해 멱등 처리로 작성한다.
+--   - 운영 DB: 인덱스가 이미 존재 → SKIP, Flyway는 V4를 '적용됨'으로 기록
+--   - 신규/로컬 DB: 인덱스 없음 → CREATE
+SET @exists := (
+    SELECT COUNT(*) FROM information_schema.statistics
+    WHERE table_schema = DATABASE()
+      AND table_name = 'place_category'
+      AND index_name = 'idx_placecategory_theme'
+  );
+  SET @ddl := IF(@exists = 0,
+    'CREATE INDEX idx_placecategory_theme ON place_category (theme)',
+    'SELECT 1');
+PREPARE stmt FROM @ddl;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;


### PR DESCRIPTION
## 🔖 관련 이슈
> (예시) Closes #103
- Closes #80 

## 🛠️ 작업 내용

- 마이그레이션 파일 추가

## 🎨 스크린샷 / 화면 예시 (선택)
### 🕒 수정 전

-

### ✨ 수정 후

`V4__add_placecategory_theme_index`

```sql
-- place_category.theme 조회 성능 인덱스 (PlaceCategoryRepository.findFirstByTheme 대상)
-- 운영 DB(toleave)에는 2026-06-12 수동 CREATE INDEX로 이미 생성됨(마이그레이션 미기록 상태였음).
-- 신규/로컬 DB에는 없으므로, 환경 간 SSOT를 맞추기 위해 멱등 처리로 작성한다.
--   - 운영 DB: 인덱스가 이미 존재 → SKIP, Flyway는 V4를 '적용됨'으로 기록
--   - 신규/로컬 DB: 인덱스 없음 → CREATE
SET @exists := (
    SELECT COUNT(*) FROM information_schema.statistics
    WHERE table_schema = DATABASE()
      AND table_name = 'place_category'
      AND index_name = 'idx_placecategory_theme'
  );
  SET @ddl := IF(@exists = 0,
    'CREATE INDEX idx_placecategory_theme ON place_category (theme)',
    'SELECT 1');
PREPARE stmt FROM @ddl;
EXECUTE stmt;
DEALLOCATE PREPARE stmt;
```

## 👀 리뷰 요청 사항 (선택)
> 특별히 리뷰어가 봐줬으면 하는 부분이 있다면 적어주세요
- 