### PR TITLE
[fix]: WebSocket 인증 방식을 URL 쿼리 파라미터에서 httpOnly 쿠키로 변경

### DIFF
--- a/backend/src/main/java/org/example/be/domain/chat/interceptor/CustomHandshakeInterceptor.java
+++ b/backend/src/main/java/org/example/be/domain/chat/interceptor/CustomHandshakeInterceptor.java
@@ -1,6 +1,7 @@
 package org.example.be.domain.chat.interceptor;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -33,7 +34,7 @@ public class CustomHandshakeInterceptor implements HandshakeInterceptor {
 		WebSocketHandler wsHandler, Map<String, Object> attributes) {
 
 		HttpServletRequest servletRequest = ((ServletServerHttpRequest)request).getServletRequest();
-		String accessToken = servletRequest.getParameter("accessToken");
+		String accessToken = extractCookie(servletRequest, "accessToken");
 		String groupName = servletRequest.getParameter("groupName");
 
 		log.debug("[WebSocket Debug] Handshake attempt - groupName: {}", groupName);
@@ -71,6 +72,17 @@ public class CustomHandshakeInterceptor implements HandshakeInterceptor {
 		log.debug("[WebSocket Debug] Handshake successful");
 
 		return true;
+	}
+
+	private String extractCookie(HttpServletRequest request, String name) {
+		if (request.getCookies() == null) {
+			return null;
+		}
+		return Arrays.stream(request.getCookies())
+			.filter(cookie -> cookie.getName().equals(name))
+			.map(jakarta.servlet.http.Cookie::getValue)
+			.findFirst()
+			.orElse(null);
 	}
 
 	private boolean failHandshake(ServerHttpResponse response, String message) {


### PR DESCRIPTION
## 🔖 관련 이슈
> (예시) Closes #103
- Closes #90 

## 🛠️ 작업 내용
> 이번 PR에서 어떤 작업을 했는지 간단히 요약하세요
- `CustomHandshakeInterceptor`에서 accessToken을 쿼리 파라미터가 아닌 요청의 Cookie에서 직접 추출하도록 변경

- `groupName`은 기존과 동일하게 쿼리 파라미터로 유지

## 🎨 스크린샷 / 화면 예시 (선택)
### 🕒 수정 전

- accessToken이 URL에 노출되어 로그, 브라우저 히스토리, 리퍼러 등에 남을 수 있음
-  accessToken 쿠키가 httpOnly로 설정되어 있어 프론트에서 JS로 값을 읽어 URL에 담는 것 자체가 불가능한 상태였음

### ✨ 수정 후

-

## 👀 리뷰 요청 사항 (선택)
> 특별히 리뷰어가 봐줬으면 하는 부분이 있다면 적어주세요
- WebSocket 연결 URL에서 `?accessToken=...` 제거하십시오
-  `withCredentials: true` 옵션 프론트에서 켜야합니당