### PR TITLE
feat(schedule): 가장 가까운 예정 일정 조회 API 추가

### DIFF
--- a/backend/src/main/java/org/example/be/domain/schedule/controller/ScheduleController.java
+++ b/backend/src/main/java/org/example/be/domain/schedule/controller/ScheduleController.java
@@ -1,8 +1,10 @@
 package org.example.be.domain.schedule.controller;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.example.be.domain.schedule.dto.request.ScheduleReqBody;
+import org.example.be.domain.schedule.dto.response.NearestScheduleResBody;
 import org.example.be.domain.schedule.dto.response.ScheduleResBody;
 import org.example.be.domain.schedule.dto.response.ScheduleSummaryResBody;
 import org.example.be.domain.schedule.service.ScheduleService;
@@ -56,6 +58,19 @@ public class ScheduleController {
 	) {
 		List<ScheduleSummaryResBody> summaries = scheduleService.getScheduleList(securityUser.getId());
 		return ResponseEntity.ok(CommonResponse.success(summaries, "일정 요약 목록 조회 성공"));
+	}
+
+	// 가장 가까운 예정 일정 조회
+	@GetMapping("/nearest")
+	public ResponseEntity<CommonResponse<NearestScheduleResBody>> getNearestSchedule(
+		@AuthenticationPrincipal SecurityUser securityUser
+	) {
+		Optional<NearestScheduleResBody> response = scheduleService.getNearestSchedule(securityUser.getId());
+		if (response.isEmpty()) {
+			return ResponseEntity.ok(CommonResponse.success(null, "시작될 일정이 없습니다."));
+		}
+
+		return ResponseEntity.ok(CommonResponse.success(response.get(), "가장 가까운 일정 조회 성공"));
 	}
 
 	// 일정 수정하기

--- a/backend/src/main/java/org/example/be/domain/schedule/dto/response/NearestScheduleResBody.java
+++ b/backend/src/main/java/org/example/be/domain/schedule/dto/response/NearestScheduleResBody.java
@@ -1,0 +1,22 @@
+package org.example.be.domain.schedule.dto.response;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+
+import org.example.be.domain.schedule.entity.Schedule;
+
+public record NearestScheduleResBody(
+	String groupName,
+	LocalDate startSchedule,
+	long dDay
+) {
+	public static NearestScheduleResBody from(Schedule schedule, LocalDate today) {
+		LocalDate startSchedule = schedule.getStartSchedule().toLocalDate();
+
+		return new NearestScheduleResBody(
+			schedule.getGroup().getGroupName(),
+			startSchedule,
+			ChronoUnit.DAYS.between(today, startSchedule)
+		);
+	}
+}

--- a/backend/src/main/java/org/example/be/domain/schedule/repository/ScheduleRepository.java
+++ b/backend/src/main/java/org/example/be/domain/schedule/repository/ScheduleRepository.java
@@ -1,11 +1,11 @@
 package org.example.be.domain.schedule.repository;
 
+import java.util.Optional;
+
 import org.example.be.domain.group.entity.Group;
 import org.example.be.domain.schedule.entity.Schedule;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
-
 public interface ScheduleRepository extends JpaRepository<Schedule, Long>, ScheduleRepositoryCustom {
-    Optional<Schedule> findByGroup(Group group);
+	Optional<Schedule> findByGroup(Group group);
 }

--- a/backend/src/main/java/org/example/be/domain/schedule/repository/ScheduleRepositoryCustom.java
+++ b/backend/src/main/java/org/example/be/domain/schedule/repository/ScheduleRepositoryCustom.java
@@ -1,10 +1,14 @@
 package org.example.be.domain.schedule.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import org.example.be.domain.group.entity.Group;
 import org.example.be.domain.schedule.entity.Schedule;
 
 public interface ScheduleRepositoryCustom {
 	List<Schedule> findAllByGroupsFetchJoin(List<Group> groups);
+
+	Optional<Schedule> findNearestUpcomingByMemberId(Long memberId, LocalDateTime startOfToday);
 }

--- a/backend/src/main/java/org/example/be/domain/schedule/repository/ScheduleRepositoryCustomImpl.java
+++ b/backend/src/main/java/org/example/be/domain/schedule/repository/ScheduleRepositoryCustomImpl.java
@@ -1,10 +1,13 @@
 package org.example.be.domain.schedule.repository;
 
 import static org.example.be.domain.group.entity.QGroup.*;
+import static org.example.be.domain.member.entity.QMember.*;
 import static org.example.be.domain.schedule.entity.QSchedule.*;
 import static org.example.be.domain.schedule.entity.QSchedulePlace.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import org.example.be.domain.group.entity.Group;
 import org.example.be.domain.schedule.entity.Schedule;
@@ -27,5 +30,24 @@ public class ScheduleRepositoryCustomImpl implements ScheduleRepositoryCustom {
 			.where(schedule.group.in(groups))
 			.distinct()
 			.fetch();
+	}
+
+	@Override
+	public Optional<Schedule> findNearestUpcomingByMemberId(Long memberId, LocalDateTime startOfToday) {
+		return Optional.ofNullable(
+			queryFactory
+				.selectFrom(schedule)
+				.join(schedule.group, group).fetchJoin()
+				.join(group.members, member)
+				.where(
+					member.id.eq(memberId),
+					schedule.startSchedule.goe(startOfToday)
+				)
+				.orderBy(
+					schedule.startSchedule.asc(),
+					schedule.id.asc()
+				)
+				.fetchFirst()
+		);
 	}
 }

--- a/backend/src/main/java/org/example/be/domain/schedule/service/ScheduleService.java
+++ b/backend/src/main/java/org/example/be/domain/schedule/service/ScheduleService.java
@@ -1,5 +1,7 @@
 package org.example.be.domain.schedule.service;
 
+import java.time.Clock;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -7,6 +9,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -28,6 +31,7 @@ import org.example.be.domain.place.theme.PlaceCategoryRepository;
 import org.example.be.domain.place.touristspot.entity.TouristSpot;
 import org.example.be.domain.place.touristspot.repository.TouristSpotRepository;
 import org.example.be.domain.schedule.dto.request.ScheduleReqBody;
+import org.example.be.domain.schedule.dto.response.NearestScheduleResBody;
 import org.example.be.domain.schedule.dto.response.PlaceSimpleResBody;
 import org.example.be.domain.schedule.dto.response.ScheduleResBody;
 import org.example.be.domain.schedule.dto.response.ScheduleSummaryResBody;
@@ -55,6 +59,7 @@ public class ScheduleService {
 	private final TourRegionRepository tourRegionRepository;
 	private final PlaceCategoryRepository placeCategoryRepository;
 	private final MemberService memberService;
+	private final Clock clock;
 
 	// 일정 생성
 	@Transactional
@@ -212,6 +217,19 @@ public class ScheduleService {
 
 			})
 			.toList();
+	}
+
+	// 가장 가까운 예정 일정 조회
+	@Transactional(readOnly = true)
+	public Optional<NearestScheduleResBody> getNearestSchedule(Long userId) {
+		LocalDate today = LocalDate.now(clock);
+
+		return scheduleRepository
+			.findNearestUpcomingByMemberId(
+				userId,
+				today.atStartOfDay()
+			)
+			.map(schedule -> NearestScheduleResBody.from(schedule, today));
 	}
 
 	// 일정 수정

--- a/backend/src/main/java/org/example/be/global/config/AppConfig.java
+++ b/backend/src/main/java/org/example/be/global/config/AppConfig.java
@@ -1,5 +1,8 @@
 package org.example.be.global.config;
 
+import java.time.Clock;
+import java.time.ZoneId;
+
 import org.example.be.global.jwt.util.JsonUt;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -12,7 +15,14 @@ import jakarta.annotation.PostConstruct;
 
 @Configuration
 public class AppConfig {
+	private static final ZoneId SERVICE_ZONE_ID = ZoneId.of("Asia/Seoul");
+
 	public static ObjectMapper objectMapper;
+
+	@Bean
+	public Clock clock() {
+		return Clock.system(SERVICE_ZONE_ID);
+	}
 
 	@Bean
 	public RestTemplate restTemplate() {

--- a/backend/src/main/java/org/example/be/global/security/config/SecurityConfig.java
+++ b/backend/src/main/java/org/example/be/global/security/config/SecurityConfig.java
@@ -67,6 +67,7 @@ public class SecurityConfig {
 				.requestMatchers("/ws/**").permitAll()
 				.requestMatchers("/error").permitAll()
 				.requestMatchers("/health").permitAll()
+				.requestMatchers(HttpMethod.GET, "/schedule/nearest").authenticated()
 				.requestMatchers(HttpMethod.GET, "/schedule/get/**").permitAll()
 				.requestMatchers(HttpMethod.GET, "/schedule/getList").authenticated()
 				.anyRequest().authenticated()

--- a/backend/src/test/java/org/example/be/domain/schedule/controller/ScheduleControllerIT.java
+++ b/backend/src/test/java/org/example/be/domain/schedule/controller/ScheduleControllerIT.java
@@ -1,0 +1,91 @@
+package org.example.be.domain.schedule.controller;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import org.example.be.domain.schedule.dto.response.NearestScheduleResBody;
+import org.example.be.domain.schedule.service.ScheduleService;
+import org.example.be.global.security.config.SecurityUser;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Tag("integration")
+@DisplayName("ScheduleController 가장 가까운 예정 일정 조회 통합 테스트")
+class ScheduleControllerIT {
+
+	private static final long USER_ID = 10L;
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockitoBean
+	private ScheduleService scheduleService;
+
+	@Test
+	@DisplayName("인증 사용자의 가장 가까운 일정을 CommonResponse로 반환한다")
+	void nearestSchedule_returnsSuccessResponse() throws Exception {
+		NearestScheduleResBody response = new NearestScheduleResBody(
+			"제주 여행",
+			LocalDate.of(2026, 7, 18),
+			2L
+		);
+		when(scheduleService.getNearestSchedule(USER_ID)).thenReturn(Optional.of(response));
+
+		mockMvc.perform(get("/schedule/nearest").with(authedUser()))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.status").value(200))
+			.andExpect(jsonPath("$.message").value("가장 가까운 일정 조회 성공"))
+			.andExpect(jsonPath("$.data.groupName").value("제주 여행"))
+			.andExpect(jsonPath("$.data.startSchedule").value("2026-07-18"))
+			.andExpect(jsonPath("$.data.dDay").value(2));
+
+		verify(scheduleService).getNearestSchedule(USER_ID);
+	}
+
+	@Test
+	@DisplayName("시작될 일정이 없으면 data 없이 200과 안내 메시지를 반환한다")
+	void noUpcomingSchedule_returnsSuccessWithoutData() throws Exception {
+		when(scheduleService.getNearestSchedule(USER_ID)).thenReturn(Optional.empty());
+
+		mockMvc.perform(get("/schedule/nearest").with(authedUser()))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.status").value(200))
+			.andExpect(jsonPath("$.message").value("시작될 일정이 없습니다."))
+			.andExpect(jsonPath("$.data").doesNotExist());
+	}
+
+	@Test
+	@DisplayName("인증되지 않은 요청은 401이고 서비스에 도달하지 않는다")
+	void unauthenticated_returnsUnauthorized() throws Exception {
+		mockMvc.perform(get("/schedule/nearest"))
+			.andExpect(status().isUnauthorized())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.status").value(401))
+			.andExpect(jsonPath("$.message").value("로그인 후 이용해주세요."));
+
+		verifyNoInteractions(scheduleService);
+	}
+
+	private static RequestPostProcessor authedUser() {
+		SecurityUser principal = new SecurityUser(USER_ID, "tester@example.com", "pw", "tester", List.of());
+		return authentication(new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities()));
+	}
+}

--- a/backend/src/test/java/org/example/be/domain/schedule/repository/ScheduleRepositoryIT.java
+++ b/backend/src/test/java/org/example/be/domain/schedule/repository/ScheduleRepositoryIT.java
@@ -1,0 +1,69 @@
+package org.example.be.domain.schedule.repository;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import org.example.be.domain.group.entity.Group;
+import org.example.be.domain.group.repository.GroupRepository;
+import org.example.be.domain.member.entity.Member;
+import org.example.be.domain.member.repository.MemberRepository;
+import org.example.be.domain.schedule.entity.Schedule;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceUnitUtil;
+
+@SpringBootTest
+@Tag("integration")
+@Transactional
+@DisplayName("ScheduleRepository 가장 가까운 예정 일정 QueryDSL 통합 테스트")
+class ScheduleRepositoryIT {
+
+	@Autowired
+	private ScheduleRepository scheduleRepository;
+	@Autowired
+	private GroupRepository groupRepository;
+	@Autowired
+	private MemberRepository memberRepository;
+	@Autowired
+	private EntityManager entityManager;
+
+	@Test
+	@DisplayName("과거 일정을 제외하고 가장 가까운 일정과 그룹을 한 번에 조회한다")
+	void findNearestUpcoming_excludesPastAndFetchJoinsGroup() {
+		String suffix = UUID.randomUUID().toString();
+		Member member = memberRepository.save(
+			Member.createForJoin("nearest-" + suffix + "@example.com", "tester", "password")
+		);
+
+		saveSchedule(member, "past-" + suffix, LocalDateTime.of(2026, 7, 15, 9, 0));
+		saveSchedule(member, "nearest-" + suffix, LocalDateTime.of(2026, 7, 18, 18, 0));
+		saveSchedule(member, "far-" + suffix, LocalDateTime.of(2026, 7, 25, 9, 0));
+
+		entityManager.flush();
+		entityManager.clear();
+
+		Schedule result = scheduleRepository.findNearestUpcomingByMemberId(
+			member.getId(),
+			LocalDateTime.of(2026, 7, 16, 0, 0)
+		).orElseThrow();
+
+		assertThat(result.getStartSchedule()).isEqualTo(LocalDateTime.of(2026, 7, 18, 18, 0));
+		assertThat(result.getGroup().getGroupName()).isEqualTo("nearest-" + suffix);
+
+		PersistenceUnitUtil persistenceUnitUtil = entityManager.getEntityManagerFactory().getPersistenceUnitUtil();
+		assertThat(persistenceUnitUtil.isLoaded(result.getGroup())).isTrue();
+	}
+
+	private void saveSchedule(Member member, String groupName, LocalDateTime startSchedule) {
+		Group group = groupRepository.save(Group.create(groupName, member, "test group"));
+		scheduleRepository.save(Schedule.create(startSchedule, startSchedule.plusDays(1), group));
+	}
+}

--- a/backend/src/test/java/org/example/be/domain/schedule/service/ScheduleServiceNearestScheduleTest.java
+++ b/backend/src/test/java/org/example/be/domain/schedule/service/ScheduleServiceNearestScheduleTest.java
@@ -1,0 +1,95 @@
+package org.example.be.domain.schedule.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Optional;
+
+import org.example.be.domain.group.entity.Group;
+import org.example.be.domain.schedule.dto.response.NearestScheduleResBody;
+import org.example.be.domain.schedule.entity.Schedule;
+import org.example.be.domain.schedule.repository.ScheduleRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@DisplayName("ScheduleService 가장 가까운 예정 일정 조회 단위 테스트")
+@ExtendWith(MockitoExtension.class)
+class ScheduleServiceNearestScheduleTest {
+
+	private static final Long USER_ID = 10L;
+	private static final ZoneId SEOUL = ZoneId.of("Asia/Seoul");
+	private static final LocalDate TODAY = LocalDate.of(2026, 7, 16);
+
+	@Mock
+	private ScheduleRepository scheduleRepository;
+	@Mock
+	private Clock clock;
+
+	@InjectMocks
+	private ScheduleService scheduleService;
+
+	@BeforeEach
+	void setUpClock() {
+		when(clock.instant()).thenReturn(Instant.parse("2026-07-16T05:00:00Z"));
+		when(clock.getZone()).thenReturn(SEOUL);
+	}
+
+	@Test
+	@DisplayName("오늘 시작 시각이 이미 지났어도 날짜 기준 D-Day는 0이다")
+	void todaySchedule_returnsZeroDDay() {
+		Schedule schedule = schedule("제주 여행", LocalDateTime.of(2026, 7, 16, 8, 0));
+		when(scheduleRepository.findNearestUpcomingByMemberId(USER_ID, TODAY.atStartOfDay()))
+			.thenReturn(Optional.of(schedule));
+
+		Optional<NearestScheduleResBody> result = scheduleService.getNearestSchedule(USER_ID);
+
+		assertThat(result).hasValueSatisfying(response -> {
+			assertThat(response.groupName()).isEqualTo("제주 여행");
+			assertThat(response.startSchedule()).isEqualTo(TODAY);
+			assertThat(response.dDay()).isZero();
+		});
+		verify(scheduleRepository).findNearestUpcomingByMemberId(USER_ID, TODAY.atStartOfDay());
+	}
+
+	@Test
+	@DisplayName("미래 일정은 오늘과 시작 날짜 사이의 날짜 차이를 반환한다")
+	void futureSchedule_returnsDateDifference() {
+		Schedule schedule = schedule("부산 여행", LocalDateTime.of(2026, 7, 19, 23, 30));
+		when(scheduleRepository.findNearestUpcomingByMemberId(USER_ID, TODAY.atStartOfDay()))
+			.thenReturn(Optional.of(schedule));
+
+		Optional<NearestScheduleResBody> result = scheduleService.getNearestSchedule(USER_ID);
+
+		assertThat(result).hasValueSatisfying(response -> {
+			assertThat(response.startSchedule()).isEqualTo(LocalDate.of(2026, 7, 19));
+			assertThat(response.dDay()).isEqualTo(3L);
+		});
+	}
+
+	@Test
+	@DisplayName("시작될 일정이 없으면 빈 Optional을 반환한다")
+	void noUpcomingSchedule_returnsEmpty() {
+		when(scheduleRepository.findNearestUpcomingByMemberId(USER_ID, TODAY.atStartOfDay()))
+			.thenReturn(Optional.empty());
+
+		Optional<NearestScheduleResBody> result = scheduleService.getNearestSchedule(USER_ID);
+
+		assertThat(result).isEmpty();
+	}
+
+	private Schedule schedule(String groupName, LocalDateTime startSchedule) {
+		Group group = mock(Group.class);
+		when(group.getGroupName()).thenReturn(groupName);
+		return Schedule.create(startSchedule, startSchedule.plusDays(1), group);
+	}
+}


### PR DESCRIPTION
## 🔖 관련 이슈

- Closes #92 

## 🛠️ 작업 내용
> 이번 PR에서 어떤 작업을 했는지 간단히 요약하세요
- 인증 사용자가 참여한 그룹 중 가장 가까운 예정 일정 한 건을 조회하는 `GET /schedule/nearest` API를 추가했습니다.
- 서울 시간대의 오늘 날짜를 기준으로 일정을 조회하고 날짜 차이로 D-day를 계산합니다.
  - 오늘 일정은 시작 시간이 지났더라도 `dDay: 0`으로 반환합니다.
  - 일정 시작일은 `LocalDate` 형식으로 반환합니다.
- 예정 일정이 없으면 HTTP 200과 `"시작될 일정이 없습니다."` 메시지를 반환하며 `data` 필드는 생략합니다.
- QueryDSL 커스텀 조회를 적용했습니다.
  - 사용자 그룹 멤버십 inner join
  - 오늘 이후 일정 필터링
  - 일정 시작 시각 및 일정 ID 오름차순 정렬
  - `fetchFirst()`를 통한 단건 조회
  - 그룹 fetch join을 통한 추가 LAZY 조회 방지
- `Asia/Seoul` 기반 `Clock` Bean을 추가해 날짜 계산을 테스트할 수 있도록 구성했습니다.
- 신규 API를 인증 전용 경로로 명시했습니다.
- 서비스 단위 테스트, 컨트롤러 통합 테스트, QueryDSL 저장소 통합 테스트를 추가했습니다.

## 🎨 스크린샷 / 화면 예시 (선택)
### 🕒 수정 전

- 기존에 없던 API

### ✨ 수정 후

미래 일정 조회:

  ```json
  {
    "success": true,
    "status": 200,
    "message": "가장 가까운 일정 조회 성공",
    "data": {
      "groupName": "제주여행",
      "startSchedule": "2026-07-19",
      "dDay": 3
    }
  }
  ```

  오늘 일정 조회:

  ```json
  {
    "success": true,
    "status": 200,
    "message": "가장 가까운 일정 조회 성공",
    "data": {
      "groupName": "제주여행",
      "startSchedule": "2026-07-16",
      "dDay": 0
    }
  }
  ```

  예정 일정 없음:

  ```json
  {
    "success": true,
    "status": 200,
    "message": "시작될 일정이 없습니다."
  }
  ```

  비인증 요청:

  ```json
  {
    "success": false,
    "status": 401,
    "message": "로그인 후 이용해주세요."
  }
  ```

## 👀 리뷰 요청 사항 (선택)

- 