### PR TITLE
feat(chat): 키워드 검색에 커서 기반 방향 페이지네이션 추가

### DIFF
--- a/backend/src/main/java/org/example/be/domain/chat/controller/ChatMessageController.java
+++ b/backend/src/main/java/org/example/be/domain/chat/controller/ChatMessageController.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import org.example.be.domain.chat.dto.ChatMessageResBody;
 import org.example.be.domain.chat.dto.ChatRoomListWithLatestMessageResBody;
 import org.example.be.domain.chat.service.ChatMessageService;
+import org.example.be.domain.chat.type.SearchDirection;
 import org.example.be.global.response.CommonResponse;
 import org.example.be.global.security.config.SecurityUser;
 import org.example.be.global.util.DecodedPathVariable;
@@ -50,14 +51,17 @@ public class ChatMessageController {
 		return ResponseEntity.status(HttpStatus.OK).body(CommonResponse.success(result, "이전 메시지 추가 20개 조회 성공"));
 	}
 
-	// 키워드 기반 메시지 조회 ( 메시지 검색 )
+	// 키워드 기반 메시지 조회 ( 메시지 검색, lastMessageId 기준 direction 방향으로 20개씩 페이지네이션 )
 	@GetMapping("/{groupName}/messages/search")
 	public ResponseEntity<CommonResponse<Map<String, Object>>> searchMessages(
 		@DecodedPathVariable String groupName,
 		@RequestParam String keyword,
+		@RequestParam(required = false) Long lastMessageId,
+		@RequestParam(required = false, defaultValue = "BEFORE") SearchDirection direction,
 		@AuthenticationPrincipal SecurityUser user
 	) {
-		Map<String, Object> result = chatMessageService.searchMessages(groupName, keyword, user.getId());
+		Map<String, Object> result = chatMessageService.searchMessages(groupName, keyword, lastMessageId, direction,
+			user.getId());
 		return ResponseEntity.status(HttpStatus.OK).body(CommonResponse.success(result, "메시지 검색 성공"));
 	}
 

--- a/backend/src/main/java/org/example/be/domain/chat/repository/ChatMessageRepositoryCustom.java
+++ b/backend/src/main/java/org/example/be/domain/chat/repository/ChatMessageRepositoryCustom.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.example.be.domain.chat.entity.ChatMessage;
+import org.example.be.domain.chat.type.SearchDirection;
 import org.example.be.domain.group.entity.Group;
 
 public interface ChatMessageRepositoryCustom {
@@ -15,8 +16,9 @@ public interface ChatMessageRepositoryCustom {
 	// 이전 메시지 추가 조회 ( 무한스크롤용, fetch join 적용 )
 	List<ChatMessage> findPreviousMessages(Group group, Long lastMessageId, int limit);
 
-	// 키워드 검색 ( fetch join 적용 )
-	List<ChatMessage> searchMessagesWithKeyword(Group group, String keyword);
+	// 키워드 검색 ( 커서 기반 페이지네이션, direction으로 이전/다음 매치 조회, fetch join 적용 )
+	List<ChatMessage> searchMessagesWithKeyword(Group group, String keyword, Long lastMessageId,
+		SearchDirection direction, int limit);
 
 	// 그룹별 최신 메시지 1개 조회 ( fetch join 적용 )
 	Optional<ChatMessage> findLatestMessage(Group group);

--- a/backend/src/main/java/org/example/be/domain/chat/repository/ChatMessageRepositoryImpl.java
+++ b/backend/src/main/java/org/example/be/domain/chat/repository/ChatMessageRepositoryImpl.java
@@ -9,8 +9,10 @@ import java.util.Optional;
 
 import org.example.be.domain.chat.entity.ChatMessage;
 import org.example.be.domain.chat.entity.QChatMessage;
+import org.example.be.domain.chat.type.SearchDirection;
 import org.example.be.domain.group.entity.Group;
 
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -72,17 +74,35 @@ public class ChatMessageRepositoryImpl implements ChatMessageRepositoryCustom {
 	}
 
 	@Override
-	public List<ChatMessage> searchMessagesWithKeyword(Group targetGroup, String keyword) {
+	public List<ChatMessage> searchMessagesWithKeyword(Group targetGroup, String keyword, Long lastMessageId,
+		SearchDirection direction, int limit) {
 		return queryFactory
 			.selectFrom(chatMessage)
 			.join(chatMessage.group, group).fetchJoin()
 			.join(chatMessage.sender, member).fetchJoin()
 			.where(
 				chatMessage.group.eq(targetGroup),
-				chatMessage.content.containsIgnoreCase(keyword)
+				chatMessage.content.containsIgnoreCase(keyword),
+				cursorCondition(lastMessageId, direction)
 			)
-			.orderBy(chatMessage.createdTime.desc())
+			.orderBy(cursorOrder(direction))
+			.limit(limit)
 			.fetch();
+	}
+
+	// lastMessageId가 없으면(첫 페이지) 조건 없음, BEFORE면 과거 매치, AFTER면 최신 매치
+	private BooleanExpression cursorCondition(Long lastMessageId, SearchDirection direction) {
+		if (lastMessageId == null) {
+			return null;
+		}
+		return direction == SearchDirection.AFTER
+			? chatMessage.id.gt(lastMessageId)
+			: chatMessage.id.lt(lastMessageId);
+	}
+
+	// AFTER는 커서와 가장 가까운 최신 매치부터 limit개 뽑기 위해 오름차순, 그 외(BEFORE, 첫 페이지)는 내림차순
+	private OrderSpecifier<Long> cursorOrder(SearchDirection direction) {
+		return direction == SearchDirection.AFTER ? chatMessage.id.asc() : chatMessage.id.desc();
 	}
 
 	@Override

--- a/backend/src/main/java/org/example/be/domain/chat/service/ChatMessageService.java
+++ b/backend/src/main/java/org/example/be/domain/chat/service/ChatMessageService.java
@@ -12,6 +12,7 @@ import org.example.be.domain.chat.dto.ChatRoomListWithLatestMessageResBody;
 import org.example.be.domain.chat.entity.ChatMessage;
 import org.example.be.domain.chat.repository.ChatMessageRepository;
 import org.example.be.domain.chat.type.MessageType;
+import org.example.be.domain.chat.type.SearchDirection;
 import org.example.be.domain.group.entity.Group;
 import org.example.be.domain.group.repository.GroupRepository;
 import org.example.be.domain.member.dto.response.MemberDto;
@@ -64,12 +65,14 @@ public class ChatMessageService {
 		return buildMessageWithProfiles(messages);
 	}
 
-	// 키워드 기반 메시지 검색
+	// 키워드 기반 메시지 검색 ( 커서(lastMessageId) 기준 방향(direction)으로 20개씩 페이지네이션 )
 	@Transactional(readOnly = true)
-	public Map<String, Object> searchMessages(String groupName, String keyword, Long memberId) {
+	public Map<String, Object> searchMessages(String groupName, String keyword, Long lastMessageId,
+		SearchDirection direction, Long memberId) {
 		Group group = findGroupAndValidateMember(groupName, memberId);
 
-		List<ChatMessage> messages = chatMessageRepository.searchMessagesWithKeyword(group, keyword);
+		List<ChatMessage> messages = chatMessageRepository.searchMessagesWithKeyword(group, keyword, lastMessageId,
+			direction, 20);
 
 		return buildMessageWithProfiles(messages);
 	}

--- a/backend/src/main/java/org/example/be/domain/chat/type/SearchDirection.java
+++ b/backend/src/main/java/org/example/be/domain/chat/type/SearchDirection.java
@@ -1,0 +1,6 @@
+package org.example.be.domain.chat.type;
+
+public enum SearchDirection {
+	BEFORE, // 커서보다 과거 매치 ( 스크롤 업 )
+	AFTER   // 커서보다 최신 매치 ( 스크롤 다운 )
+}


### PR DESCRIPTION
## 🔖 관련 이슈
> (예시) Closes #103
- Closes #94 

## 🛠️ 작업 내용
> 이번 PR에서 어떤 작업을 했는지 간단히 요약하세요
- SearchDirection enum(BEFORE/AFTER) 추가 — 커서 기준 과거/최신 방향 구분
- ChatMessageRepositoryCustom / ChatMessageRepositoryImpl.searchMessagesWithKeyword: lastMessageId, direction, limit 파라미터를 받아 동적 쿼리로 처리
  - lastMessageId 없음(첫 페이지): 최신 매치부터 limit개
  - direction=BEFORE: id < lastMessageId, 내림차순으로 커서 이전 매치
  - direction=AFTER: id > lastMessageId, 오름차순으로 커서 이후 매치(커서와 가장 가까운 것부터)
- ChatMessageService.searchMessages: 위 파라미터 전달, limit 20 고정
- ChatMessageController: lastMessageId(옵션), direction(옵션, 기본값 BEFORE) 쿼리 파라미터 추가. 엔드포인트 경로는 기존과 동일(/chat/{groupName}/messages/search)

## 🎨 스크린샷 / 화면 예시 (선택)
### 🕒 수정 전

-

### ✨ 수정 후

-

## 👀 리뷰 요청 사항 (선택)
> 특별히 리뷰어가 봐줬으면 하는 부분이 있다면 적어주세요
- 첫 조회: ?keyword=검색어
- 스크롤로 과거 방향 추가 조회: ?keyword=검색어&lastMessageId=<현재 결과 중 가장 작은 id>&direction=BEFORE
- 최신 방향 추가 조회: ?keyword=검색어&lastMessageId=<현재 결과 중 가장 큰 id>&direction=AFTER