### PR TITLE
feat(chat): 키워드 검색에 커서 기반 방향 페이지네이션 추가

### DIFF
--- a/backend/src/main/java/org/example/be/domain/chat/controller/ChatMessageController.java
+++ b/backend/src/main/java/org/example/be/domain/chat/controller/ChatMessageController.java
@@ -52,10 +52,12 @@ public class ChatMessageController {
 	}
 
 	// 키워드 기반 메시지 조회 ( 메시지 검색, lastMessageId 기준 direction 방향으로 20개씩 페이지네이션 )
+	// direction=BOTH + lastMessageId만 넘기면 keyword 없이 그 메시지를 중심으로 전후 메시지를 한 번에 조회
+	// ( 검색 결과 클릭 시 그 채팅 위치로 점프하는 용도 )
 	@GetMapping("/{groupName}/messages/search")
 	public ResponseEntity<CommonResponse<Map<String, Object>>> searchMessages(
 		@DecodedPathVariable String groupName,
-		@RequestParam String keyword,
+		@RequestParam(required = false) String keyword,
 		@RequestParam(required = false) Long lastMessageId,
 		@RequestParam(required = false, defaultValue = "BEFORE") SearchDirection direction,
 		@AuthenticationPrincipal SecurityUser user

--- a/backend/src/main/java/org/example/be/domain/chat/repository/ChatMessageRepositoryCustom.java
+++ b/backend/src/main/java/org/example/be/domain/chat/repository/ChatMessageRepositoryCustom.java
@@ -17,6 +17,7 @@ public interface ChatMessageRepositoryCustom {
 	List<ChatMessage> findPreviousMessages(Group group, Long lastMessageId, int limit);
 
 	// 키워드 검색 ( 커서 기반 페이지네이션, direction으로 이전/다음 매치 조회, fetch join 적용 )
+	// direction=BOTH면 keyword 무시하고 lastMessageId(클릭한 메시지) 기준 전후 메시지를 한 번에 조회
 	List<ChatMessage> searchMessagesWithKeyword(Group group, String keyword, Long lastMessageId,
 		SearchDirection direction, int limit);
 

--- a/backend/src/main/java/org/example/be/domain/chat/repository/ChatMessageRepositoryImpl.java
+++ b/backend/src/main/java/org/example/be/domain/chat/repository/ChatMessageRepositoryImpl.java
@@ -4,6 +4,7 @@ import static org.example.be.domain.chat.entity.QChatMessage.*;
 import static org.example.be.domain.group.entity.QGroup.*;
 import static org.example.be.domain.member.entity.QMember.*;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -76,28 +77,51 @@ public class ChatMessageRepositoryImpl implements ChatMessageRepositoryCustom {
 	@Override
 	public List<ChatMessage> searchMessagesWithKeyword(Group targetGroup, String keyword, Long lastMessageId,
 		SearchDirection direction, int limit) {
+		// BOTH: 검색 결과에서 특정 메시지를 클릭했을 때, 키워드와 무관하게 그 메시지를 중심으로
+		// 이전/이후 메시지를 한 번에 가져와 채팅창을 그 위치로 점프시키기 위한 용도.
+		if (direction == SearchDirection.BOTH) {
+			List<ChatMessage> before = fetchDirectional(targetGroup, null, lastMessageId, SearchDirection.BEFORE,
+				limit, false);
+			List<ChatMessage> after = fetchDirectional(targetGroup, null, lastMessageId, SearchDirection.AFTER,
+				limit, true);
+			List<ChatMessage> combined = new ArrayList<>(before);
+			combined.addAll(after);
+			return combined;
+		}
+		return fetchDirectional(targetGroup, keyword, lastMessageId, direction, limit, false);
+	}
+
+	private List<ChatMessage> fetchDirectional(Group targetGroup, String keyword, Long lastMessageId,
+		SearchDirection direction, int limit, boolean inclusive) {
 		return queryFactory
 			.selectFrom(chatMessage)
 			.join(chatMessage.group, group).fetchJoin()
 			.join(chatMessage.sender, member).fetchJoin()
 			.where(
 				chatMessage.group.eq(targetGroup),
-				chatMessage.content.containsIgnoreCase(keyword),
-				cursorCondition(lastMessageId, direction)
+				keywordCondition(keyword),
+				cursorCondition(lastMessageId, direction, inclusive)
 			)
 			.orderBy(cursorOrder(direction))
 			.limit(limit)
 			.fetch();
 	}
 
-	// lastMessageId가 없으면(첫 페이지) 조건 없음, BEFORE면 과거 매치, AFTER면 최신 매치
-	private BooleanExpression cursorCondition(Long lastMessageId, SearchDirection direction) {
+	// keyword가 없으면(BOTH 모드, 또는 일반 조회) 조건 없음
+	private BooleanExpression keywordCondition(String keyword) {
+		return (keyword == null || keyword.isBlank()) ? null : chatMessage.content.containsIgnoreCase(keyword);
+	}
+
+	// lastMessageId가 없으면(첫 페이지) 조건 없음, BEFORE면 과거, AFTER면 최신
+	// inclusive는 BOTH 모드의 AFTER 쪽에서 클릭한 메시지 자신도 포함시키기 위함
+	private BooleanExpression cursorCondition(Long lastMessageId, SearchDirection direction, boolean inclusive) {
 		if (lastMessageId == null) {
 			return null;
 		}
-		return direction == SearchDirection.AFTER
-			? chatMessage.id.gt(lastMessageId)
-			: chatMessage.id.lt(lastMessageId);
+		if (direction == SearchDirection.AFTER) {
+			return inclusive ? chatMessage.id.goe(lastMessageId) : chatMessage.id.gt(lastMessageId);
+		}
+		return chatMessage.id.lt(lastMessageId);
 	}
 
 	// AFTER는 커서와 가장 가까운 최신 매치부터 limit개 뽑기 위해 오름차순, 그 외(BEFORE, 첫 페이지)는 내림차순

--- a/backend/src/main/java/org/example/be/domain/chat/type/SearchDirection.java
+++ b/backend/src/main/java/org/example/be/domain/chat/type/SearchDirection.java
@@ -2,5 +2,6 @@ package org.example.be.domain.chat.type;
 
 public enum SearchDirection {
 	BEFORE, // 커서보다 과거 매치 ( 스크롤 업 )
-	AFTER   // 커서보다 최신 매치 ( 스크롤 다운 )
+	AFTER,  // 커서보다 최신 매치 ( 스크롤 다운 )
+	BOTH    // 커서(특정 메시지)를 중심으로 전후 메시지를 한 번에 ( 검색 결과 클릭 시 그 위치로 점프 )
 }


### PR DESCRIPTION
## 🔖 관련 이슈
> (예시) Closes #103
- Closes

## 🛠️ 작업 내용
> 이번 PR에서 어떤 작업을 했는지 간단히 요약하세요
  - SearchDirection enum 추가: BEFORE(과거) / AFTER(최신) / BOTH(전후 동시, keyword 무시)
  - GET /chat/{groupName}/messages/search
    - lastMessageId + direction으로 검색 결과도 기존 recent/prev와 동일하게 20개 단위 커서 페이지네이션 지원
    - keyword를 선택 파라미터로 변경
    - direction=BOTH: keyword 무시, lastMessageId(클릭한 메시지)를 중심으로 이전 20개 + 이후 20개(자기 자신 포함)를 한 번에 반환
  → 검색 결과 클릭 시 채팅 위치로 점프하는 용도


## 🎨 스크린샷 / 화면 예시 (선택)
### 🕒 수정 전

-

### ✨ 수정 후

-

## 👀 리뷰 요청 사항 (선택)
> 특별히 리뷰어가 봐줬으면 하는 부분이 있다면 적어주세요
- 