### PR TITLE
[feat] 회원 탈퇴 기능 추가 

### DIFF
--- a/backend/src/main/java/org/example/be/domain/board/repository/BoardRepository.java
+++ b/backend/src/main/java/org/example/be/domain/board/repository/BoardRepository.java
@@ -1,10 +1,17 @@
 package org.example.be.domain.board.repository;
 
 import org.example.be.domain.board.entity.Board;
+import org.example.be.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface BoardRepository extends JpaRepository<Board, Long>, BoardRepositoryCustom {
 
+	@Modifying
+	@Query("DELETE FROM Board b WHERE b.writer = :writer")
+	void deleteByWriter(@Param("writer") Member writer);
 }

--- a/backend/src/main/java/org/example/be/domain/board/repository/CommentRepository.java
+++ b/backend/src/main/java/org/example/be/domain/board/repository/CommentRepository.java
@@ -1,9 +1,18 @@
 package org.example.be.domain.board.repository;
 
 import org.example.be.domain.board.entity.Comment;
+import org.example.be.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long>, CommentRepositoryCustom {
+
+	@Modifying
+	@Query("DELETE FROM Comment c WHERE c.writer = :writer")
+	void deleteByWriter(@Param("writer") Member writer);
+
 }

--- a/backend/src/main/java/org/example/be/domain/chat/repository/ChatMessageRepository.java
+++ b/backend/src/main/java/org/example/be/domain/chat/repository/ChatMessageRepository.java
@@ -2,6 +2,7 @@ package org.example.be.domain.chat.repository;
 
 import org.example.be.domain.chat.entity.ChatMessage;
 import org.example.be.domain.group.entity.Group;
+import org.example.be.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -13,9 +14,9 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long>,
 
 	@Modifying
 	@Query("DELETE FROM ChatMessage c WHERE c.group = :group")
-	void deleteByGroup(@Param("groupId") Group group);
+	void deleteByGroup(@Param("group") Group group);
 
 	@Modifying
 	@Query("DELETE From ChatMessage c WHERE c.sender = :sender")
-	void deleteBySender(@Param("sender") String sender);
+	void deleteBySender(@Param("sender") Member sender);
 }

--- a/backend/src/main/java/org/example/be/domain/chat/repository/ChatMessageRepository.java
+++ b/backend/src/main/java/org/example/be/domain/chat/repository/ChatMessageRepository.java
@@ -1,9 +1,21 @@
 package org.example.be.domain.chat.repository;
 
 import org.example.be.domain.chat.entity.ChatMessage;
+import org.example.be.domain.group.entity.Group;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long>, ChatMessageRepositoryCustom {
+
+	@Modifying
+	@Query("DELETE FROM ChatMessage c WHERE c.group = :group")
+	void deleteByGroup(@Param("groupId") Group group);
+
+	@Modifying
+	@Query("DELETE From ChatMessage c WHERE c.sender = :sender")
+	void deleteBySender(@Param("sender") String sender);
 }

--- a/backend/src/main/java/org/example/be/domain/group/repository/GroupRepository.java
+++ b/backend/src/main/java/org/example/be/domain/group/repository/GroupRepository.java
@@ -19,6 +19,8 @@ public interface GroupRepository extends JpaRepository<Group, Long> {
 
 	boolean existsByGroupNameAndMembers_Id(String groupName, Long memberId);
 
+	List<Group> findAllByCreatedBy(Member member);
+
 	// ( 위 findByGroupName은 기본 LAZY 로딩 전략이라 서비스단 트랜잭션 밖에서 그룹 정보를 호출하면
 	// 실제 DB 쿼리가 나가지 않고 프록시 객체에만 접근할 수 있기 때문에 밖에서 사용할 수 있는 쿼리를 따로 판겁니다.)
 	// 채팅 ChannelInterceptor, 그룹 상세조회에서 사용할 fetch join 쿼리

--- a/backend/src/main/java/org/example/be/domain/group/service/GroupService.java
+++ b/backend/src/main/java/org/example/be/domain/group/service/GroupService.java
@@ -3,6 +3,7 @@ package org.example.be.domain.group.service;
 import java.util.List;
 import java.util.Optional;
 
+import org.example.be.domain.chat.repository.ChatMessageRepository;
 import org.example.be.domain.group.announcement.dto.GroupAnnouncementSummaryDTO;
 import org.example.be.domain.group.announcement.repository.GroupAnnouncementRepository;
 import org.example.be.domain.group.dto.GroupMemberDTO;
@@ -49,6 +50,7 @@ public class GroupService {
 	private final TouristSpotRepository touristSpotRepository;
 	private final AccommodationRepository accommodationRepository;
 	private final RestaurantRepository restaurantRepository;
+	private final ChatMessageRepository chatMessageRepository;
 
 	// 그룹 생성하기
 	@Transactional
@@ -163,6 +165,10 @@ public class GroupService {
 		String groupName = request.groupName();
 
 		Group group = validateGroupCreator(groupName, memberId);
+
+		chatMessageRepository.deleteByGroup(group);
+		scheduleRepository.findByGroup(group).ifPresent(scheduleRepository::delete);
+
 		groupRepository.delete(group);
 
 		return new GroupDeleteResBody(groupName);

--- a/backend/src/main/java/org/example/be/domain/member/service/MemberService.java
+++ b/backend/src/main/java/org/example/be/domain/member/service/MemberService.java
@@ -2,15 +2,22 @@ package org.example.be.domain.member.service;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
+import org.example.be.domain.board.repository.BoardRepository;
+import org.example.be.domain.board.repository.CommentRepository;
+import org.example.be.domain.chat.repository.ChatMessageRepository;
+import org.example.be.domain.group.entity.Group;
+import org.example.be.domain.group.repository.GroupRepository;
 import org.example.be.domain.member.dto.request.MemberJoinReqBody;
 import org.example.be.domain.member.dto.request.PasswordUpdateReqBody;
 import org.example.be.domain.member.dto.response.MemberProfileResBody;
 import org.example.be.domain.member.entity.Member;
 import org.example.be.domain.member.repository.MemberRepository;
-import org.example.be.storage.gcs.GCSService;
 import org.example.be.domain.member.type.OauthProvider;
+import org.example.be.domain.schedule.repository.ScheduleRepository;
+import org.example.be.storage.gcs.GCSService;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -26,6 +33,11 @@ public class MemberService {
 	private final MemberRepository memberRepository;
 	private final PasswordEncoder passwordEncoder;
 	private final GCSService gcsService;
+	private final GroupRepository groupRepository;
+	private final BoardRepository boardRepository;
+	private final ChatMessageRepository chatMessageRepository;
+	private final CommentRepository commentRepository;
+	private final ScheduleRepository scheduleRepository;
 
 	public Member join(MemberJoinReqBody reqBody) {
 		if (memberRepository.existsByEmail(reqBody.email())) {
@@ -114,8 +126,25 @@ public class MemberService {
 		member.updateSubscribed(subscribed);
 	}
 
+	@Transactional
 	public void deleteMember(long memberId) {
 		Member member = getById(memberId);
+
+		List<Group> ownedGroups = groupRepository.findAllByCreatedBy(member);
+		for (Group group : ownedGroups) {
+			chatMessageRepository.deleteByGroup(group);
+			scheduleRepository.findByGroup(group).ifPresent(scheduleRepository::delete);
+			groupRepository.delete(group);
+		}
+
+		List<Group> joinedGroups = groupRepository.findByMembersContaining(member);
+		for (Group group : joinedGroups) {
+			group.removeMember(member);
+		}
+
+		chatMessageRepository.deleteBySender(member);
+		commentRepository.deleteByWriter(member);
+		boardRepository.deleteByWriter(member);
 
 		if (member.getProfileImageUrl() != null) {
 			gcsService.deleteProfileImage(member.getProfileImageUrl());

--- a/backend/src/main/java/org/example/be/domain/member/service/MemberService.java
+++ b/backend/src/main/java/org/example/be/domain/member/service/MemberService.java
@@ -141,6 +141,7 @@ public class MemberService {
 		for (Group group : joinedGroups) {
 			group.removeMember(member);
 		}
+		groupRepository.flush();
 
 		chatMessageRepository.deleteBySender(member);
 		commentRepository.deleteByWriter(member);


### PR DESCRIPTION
## 🔖 관련 이슈
> (예시) Closes #103
- Closes #97 

## 🛠️ 작업 내용
> 이번 PR에서 어떤 작업을 했는지 간단히 요약하세요
- 하드 삭제 정책: 탈퇴 시 작성한 게시글/댓글/채팅 메시지(단톡방 포함)를 전부 하드 삭제 (개인정보 파기 관점에서 익명화보다 완전 삭제로 결정)
- 그룹 처리:
  - 창설하지 않고 가입만 한 그룹: 멤버십만 제거
  - 본인이 창설한 그룹: 그룹 자체를 통째로 삭제 (프론트에서 "탈퇴하면 그룹도 함께 삭제됩니다" 경고 후 호출된다고 가정) — 위임 기능은 없음
- GroupService.deleteGroup()도 같이 수정: 기존에 // 채팅 및 일정 연계 삭제 확인해야함로 남아있던 미해결 이슈 해결. 그룹 삭제 전 해당 그룹 채팅/일정을 먼저 정리
- 새 리포지토리 메서드(deleteByGroup, deleteBySender, deleteByWriter 등)는 전부 벌크 삭제 쿼리로 구현 (JPA cascade 대신 명시적 삭제 — Member/Group에 불필요한 역방향 컬렉션을 추가하지 않기 위함)
- 그룹 멤버십(removeMember) 처리 후 groupRepository.flush()로 즉시 반영해, 이후 회원 삭제 시점에 조인 테이블 정리가 확실히 먼저 끝나도록 처리

삭제 순서

1. 창설한 그룹: 채팅 → 일정 → 그룹 삭제
2. 가입한(창설 안 한) 그룹: 멤버십만 제거 + flush
3. 본인이 보낸 채팅 / 작성한 댓글 / 작성한 게시글 하드 삭제
4. 프로필 이미지 삭제
5. 회원 삭제

## 🎨 스크린샷 / 화면 예시 (선택)
### 🕒 수정 전

-

### ✨ 수정 후

-

## 👀 리뷰 요청 사항 (선택)
> 특별히 리뷰어가 봐줬으면 하는 부분이 있다면 적어주세요
- 