### PR TITLE
fix: 그룹 삭제 시 초대링크, 공지 삭제 로직 누락으로 인한 FK 에러 수정

### DIFF
--- a/backend/src/main/java/org/example/be/domain/group/announcement/repository/GroupAnnouncementRepository.java
+++ b/backend/src/main/java/org/example/be/domain/group/announcement/repository/GroupAnnouncementRepository.java
@@ -3,6 +3,9 @@ package org.example.be.domain.group.announcement.repository;
 import org.example.be.domain.group.announcement.entity.GroupAnnouncement;
 import org.example.be.domain.group.entity.Group;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -14,4 +17,9 @@ public interface GroupAnnouncementRepository extends JpaRepository<GroupAnnounce
     Optional<GroupAnnouncement> findTopByGroupOrderByTimeStampDesc(Group group);
     // 해당 그룹의 공지 최신순으로 전부 조회
     List<GroupAnnouncement> findAllByGroupOrderByTimeStampDesc(Group group);
+
+    // 그룹 삭제 시 해당 그룹의 공지 전부 삭제
+    @Modifying
+    @Query("DELETE FROM GroupAnnouncement ga WHERE ga.group = :group")
+    void deleteByGroup(@Param("group") Group group);
 }

--- a/backend/src/main/java/org/example/be/domain/group/invitation/repository/GroupInvitationRepository.java
+++ b/backend/src/main/java/org/example/be/domain/group/invitation/repository/GroupInvitationRepository.java
@@ -3,6 +3,9 @@ package org.example.be.domain.group.invitation.repository;
 import org.example.be.domain.group.entity.Group;
 import org.example.be.domain.group.invitation.entity.GroupInvitation;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
@@ -13,6 +16,11 @@ public interface GroupInvitationRepository extends JpaRepository<GroupInvitation
 
     // 해당 그룹에 대해; 활성 상태이고 만료 시각이 현재 시각보다 이후인 (아직 유효한) 초대링크 찾기용
     Optional<GroupInvitation> findByGroupAndActiveTrueAndExpiresAtAfter(Group group, LocalDateTime now);
+
+    // 그룹 삭제 시 해당 그룹의 초대 링크 전부 삭제
+    @Modifying
+    @Query("DELETE FROM GroupInvitation gi WHERE gi.group = :group")
+    void deleteByGroup(@Param("group") Group group);
 
 //    // 해당 초대코드에 대해; 활성 상태이고, 만료 시각이 현재 시각보다 이후인 (아직 유효한) 초대링크 찾기용
 //    Optional<GroupInvitation> findByInvitationCodeAndActiveTrueAndExpiresAtAfter(String invitationCode, LocalDateTime now);

--- a/backend/src/main/java/org/example/be/domain/group/service/GroupService.java
+++ b/backend/src/main/java/org/example/be/domain/group/service/GroupService.java
@@ -19,6 +19,7 @@ import org.example.be.domain.group.dto.response.GroupExitResBody;
 import org.example.be.domain.group.dto.response.GroupModifyResBody;
 import org.example.be.domain.group.dto.response.GroupResBody;
 import org.example.be.domain.group.entity.Group;
+import org.example.be.domain.group.invitation.repository.GroupInvitationRepository;
 import org.example.be.domain.group.repository.GroupRepository;
 import org.example.be.domain.member.entity.Member;
 import org.example.be.domain.member.service.MemberService;
@@ -45,6 +46,7 @@ public class GroupService {
 	private final MemberService memberService;
 	private final EntityManager entityManager;
 	private final GroupAnnouncementRepository groupAnnouncementRepository;
+	private final GroupInvitationRepository groupInvitationRepository;
 	private final ScheduleRepository scheduleRepository;
 	private final SchedulePlaceRepository schedulePlaceRepository;
 	private final TouristSpotRepository touristSpotRepository;
@@ -168,6 +170,8 @@ public class GroupService {
 
 		chatMessageRepository.deleteByGroup(group);
 		scheduleRepository.findByGroup(group).ifPresent(scheduleRepository::delete);
+		groupInvitationRepository.deleteByGroup(group);
+		groupAnnouncementRepository.deleteByGroup(group);
 
 		groupRepository.delete(group);
 

--- a/backend/src/main/java/org/example/be/domain/member/service/MemberService.java
+++ b/backend/src/main/java/org/example/be/domain/member/service/MemberService.java
@@ -8,7 +8,9 @@ import java.util.Optional;
 import org.example.be.domain.board.repository.BoardRepository;
 import org.example.be.domain.board.repository.CommentRepository;
 import org.example.be.domain.chat.repository.ChatMessageRepository;
+import org.example.be.domain.group.announcement.repository.GroupAnnouncementRepository;
 import org.example.be.domain.group.entity.Group;
+import org.example.be.domain.group.invitation.repository.GroupInvitationRepository;
 import org.example.be.domain.group.repository.GroupRepository;
 import org.example.be.domain.member.dto.request.MemberJoinReqBody;
 import org.example.be.domain.member.dto.request.PasswordUpdateReqBody;
@@ -34,6 +36,8 @@ public class MemberService {
 	private final PasswordEncoder passwordEncoder;
 	private final GCSService gcsService;
 	private final GroupRepository groupRepository;
+	private final GroupInvitationRepository groupInvitationRepository;
+	private final GroupAnnouncementRepository groupAnnouncementRepository;
 	private final BoardRepository boardRepository;
 	private final ChatMessageRepository chatMessageRepository;
 	private final CommentRepository commentRepository;
@@ -134,6 +138,8 @@ public class MemberService {
 		for (Group group : ownedGroups) {
 			chatMessageRepository.deleteByGroup(group);
 			scheduleRepository.findByGroup(group).ifPresent(scheduleRepository::delete);
+			groupInvitationRepository.deleteByGroup(group);
+			groupAnnouncementRepository.deleteByGroup(group);
 			groupRepository.delete(group);
 		}
 


### PR DESCRIPTION

## 🔖 관련 이슈
> (예시) Closes #103
- Closes

## 🛠️ 작업 내용
> 이번 PR에서 어떤 작업을 했는지 간단히 요약하세요
- GroupInvitationRepository, GroupAnnouncementRepository에 deleteByGroup 추가하고 GroupService.deleteGroup(), MemberService.deleteMember()에서 호출.


## 🎨 스크린샷 / 화면 예시 (선택)
### 🕒 수정 전

- 

### ✨ 수정 후

-

## 👀 리뷰 요청 사항 (선택)
> 특별히 리뷰어가 봐줬으면 하는 부분이 있다면 적어주세요
- 